### PR TITLE
fix airblast self-damage bug

### DIFF
--- a/game/server/tf/tf_obj_sentrygun.h
+++ b/game/server/tf/tf_obj_sentrygun.h
@@ -241,6 +241,9 @@ public:
 	static CTFProjectile_SentryRocket *Create( const Vector &vecOrigin, const QAngle &vecAngles, CBaseEntity *pOwner = NULL, CBaseEntity *pScorer = NULL );	
 
 	virtual void Spawn();
+	
+	// prevent sentry rockets from setting their original launcher to a flamethrower when deflected
+	virtual void SetLauncher( CBaseEntity *pLauncher ) OVERRIDE { m_hLauncher = pLauncher; }
 };
 
 #endif // TF_OBJ_SENTRYGUN_H

--- a/game/server/tf/tf_projectile_flare.cpp
+++ b/game/server/tf/tf_projectile_flare.cpp
@@ -410,7 +410,7 @@ void CTFProjectile_Flare::Explode_Air( trace_t *pTrace, int bitsDamageType, bool
 			DrawRadius( flRadius );
 		}
 #endif
-		CTakeDamageInfo info( this, pAttacker, m_hLauncher, vec3_origin, vecOrigin, GetDamage(), bitsDamageType | DMG_HALF_FALLOFF, TF_DMG_CUSTOM_FLARE_EXPLOSION );
+		CTakeDamageInfo info( this, pAttacker, GetOriginalLauncher(), vec3_origin, vecOrigin, GetDamage(), bitsDamageType | DMG_HALF_FALLOFF, TF_DMG_CUSTOM_FLARE_EXPLOSION );
 		CTFRadiusDamageInfo radiusinfo( &info, vecOrigin, flRadius, NULL, TF_FLARE_RADIUS_FOR_FJS );
 		TFGameRules()->RadiusDamage( radiusinfo );
 	}

--- a/game/shared/tf/tf_weaponbase_grenadeproj.cpp
+++ b/game/shared/tf/tf_weaponbase_grenadeproj.cpp
@@ -381,7 +381,7 @@ void CTFWeaponBaseGrenadeProj::Explode( trace_t *pTrace, int bitsDamageType )
 	// Use the thrower's position as the reported position
 	Vector vecReported = GetThrower() ? GetThrower()->GetAbsOrigin() : vec3_origin;
 	int nCustomDamage = GetDamageCustom();
-	CTakeDamageInfo info( this, GetThrower(), m_hLauncher, GetBlastForce(), GetAbsOrigin(), m_flDamage, bitsDamageType, nCustomDamage, &vecReported );
+	CTakeDamageInfo info( this, GetThrower(), GetOriginalLauncher(), GetBlastForce(), GetAbsOrigin(), m_flDamage, bitsDamageType, nCustomDamage, &vecReported );
 
 	float flRadius = GetDamageRadius();
 


### PR DESCRIPTION
reflected grenades, flares, and sentry rockets deal up to 170 self-damage because they use the flamethrower's damage value (which is set to 170 in scripts/tf_weapon_flamethrower.ctx)

rocket launchers rockets are unaffected because they correctly use the rocket launcher's damage value (https://github.com/mastercomfig/team-comtress-2/blob/e5aa982307a5a83151a3abcb9a389ba7b0746a1e/game/shared/tf/tf_weaponbase_rocket.cpp#L512)