### PR TITLE
fix sticky charge sound bug

### DIFF
--- a/game/shared/tf/tf_weapon_pipebomblauncher.cpp
+++ b/game/shared/tf/tf_weapon_pipebomblauncher.cpp
@@ -115,6 +115,14 @@ void CTFPipebombLauncher::Spawn( void )
 //-----------------------------------------------------------------------------
 bool CTFPipebombLauncher::Holster( CBaseCombatWeapon *pSwitchingTo )
 {
+#ifdef CLIENT_DLL
+	// fix charge sound not stopping on weapon switch
+	if ( m_flChargeBeginTime > 0 )
+	{
+		StopSound( TF_WEAPON_PIPEBOMB_LAUNCHER_CHARGE_SOUND );
+	}
+#endif
+
 	m_flChargeBeginTime = 0;
 
 	return BaseClass::Holster( pSwitchingTo );


### PR DESCRIPTION
fixes the bug fixed in TF2's December 13 2017 Patch:
> Fixed the charge sound for the Stickybomb Launcher not stopping if the player switches weapons while charging