### PR TITLE
fix sticky det bug (melee)

### DIFF
--- a/game/shared/tf/tf_weaponbase.cpp
+++ b/game/shared/tf/tf_weaponbase.cpp
@@ -5420,6 +5420,10 @@ bool CTFWeaponBase::CanPerformSecondaryAttack() const
 {
 	CTFPlayer *pOwner = ToTFPlayer( GetOwner() );
 
+    // fix stickies not being detonated while attacking
+    if ( pOwner->IsPlayerClass( TF_CLASS_DEMOMAN ) )
+        return true;
+
 	// Demo shields are allowed to charge whenever
 	if ( pOwner->m_Shared.HasDemoShieldEquipped() )
 		return true;

--- a/game/shared/tf/tf_weaponbase_melee.cpp
+++ b/game/shared/tf/tf_weaponbase_melee.cpp
@@ -236,6 +236,17 @@ void CTFWeaponBaseMelee::PrimaryAttack()
 // -----------------------------------------------------------------------------
 void CTFWeaponBaseMelee::SecondaryAttack()
 {
+#ifdef GAME_DLL
+	// fix stickies not being detonated while switching to melee
+	if ( CanAttack() )
+	{
+		CTFPlayer *pOwner = ToTFPlayer( GetOwner() );
+		
+		if ( pOwner->IsPlayerClass( TF_CLASS_DEMOMAN ) )
+			pOwner->DoClassSpecialSkill();
+	}
+#endif
+	
 	// semi-auto behaviour
 	if ( m_bInAttack2 )
 		return;


### PR DESCRIPTION
not a very elegant solution, but this lets the demo det stickies while swinging a melee weapon or while switching to a melee weapon