### PR TITLE
prevent newlines from being sent in chat

### DIFF
--- a/game/shared/tf/tf_gamerules.h
+++ b/game/shared/tf/tf_gamerules.h
@@ -842,6 +842,8 @@ bool IsCreepWaveMode( void ) const;
 	virtual Vector VecItemRespawnSpot( CItem *pItem );
 	virtual QAngle VecItemRespawnAngles( CItem *pItem );
 
+	virtual void CheckChatText( CBasePlayer *pPlayer, char *pText );
+
 	virtual const char *GetChatFormat( bool bTeamOnly, CBasePlayer *pPlayer );
 	void ClientSettingsChanged( CBasePlayer *pPlayer );
 	void ChangePlayerName( CTFPlayer *pPlayer, const char *pszNewName );


### PR DESCRIPTION
controlled by a new cvar: `mp_chat_clean_text`

this prevents users from disrupting the chat box by sending messages that contain newline characters (which is only possible with cheats)

cr and lf characters are replaced with question marks

this also replaces "mean spaces" like zero-width spaces with regular spaces (though im not sure if this feature is necessary or desirable)