### PR TITLE
Add Red player’s death screams in MvM

### DIFF
--- a/game/server/tf/tf_player.cpp
+++ b/game/server/tf/tf_player.cpp
@@ -14540,7 +14540,6 @@ void CTFPlayer::DeathSound( const CTakeDamageInfo &info )
 		 GetTeamNumber() != TF_TEAM_PVE_INVADERS && !m_bGoingFeignDeath )
 	{
 		EmitSound( "MVM.PlayerDied" );
-		return;
 	}
 
 	if ( m_LastDamageType & DMG_FALL ) // Did we die from falling?


### PR DESCRIPTION
Purely cosmetic change. It’s weird that players don’t make a sound when dying