### PR TITLE
Remove the slowdown on Explosive Headshot

### DIFF
--- a/game/shared/tf/tf_weaponbase.cpp
+++ b/game/shared/tf/tf_weaponbase.cpp
@@ -4916,13 +4916,6 @@ void CTFWeaponBase::ApplyOnHitAttributes( CBaseEntity *pVictimBaseEntity, CTFPla
 
 		if ( (RandomFloat() < flProcChance) )
 		{
-			// Stun the source
-			float flStunDuration = 2.f;
-			float flStunAmt = 1.f;
-			pVictim->m_Shared.StunPlayer( flStunDuration, flStunAmt, TF_STUN_MOVEMENT | TF_STUN_CONTROLS | TF_STUN_NO_EFFECTS, pAttacker );
-
-			pVictim->m_Shared.MakeBleed( ToTFPlayer( pAttacker ), NULL, flStunDuration, 75 );
-
 			// Generate an explosion and look for nearby bots
 			float flDmgRange = 100.f;
 
@@ -4959,9 +4952,6 @@ void CTFWeaponBase::ApplyOnHitAttributes( CBaseEntity *pVictimBaseEntity, CTFPla
 
 				if ( pVictim->m_Shared.IsInvulnerable() )
 					continue;
-
-				// Stun
-				pTFPlayer->m_Shared.StunPlayer( flStunDuration, flStunAmt, TF_STUN_MOVEMENT | TF_STUN_CONTROLS | TF_STUN_NO_EFFECTS, pAttacker );
 
 				// DoT
 				pTFPlayer->m_Shared.MakeBleed( ToTFPlayer( pAttacker ), NULL, flStunDuration, 75.f );


### PR DESCRIPTION
Explosive headshot is considered as a powerful upgrade, but also the bread and butter of the Sniper. It is his main upgrade that allows him to do everything he has to do. However, having the upgrade apply slowdown on top of high area damage is overkill for such a strong class.