### PR TITLE
Make money automatically collected when in Scout’s money collection r…

### DIFF
--- a/game/shared/tf/tf_player_shared.cpp
+++ b/game/shared/tf/tf_player_shared.cpp
@@ -8804,27 +8804,7 @@ void CTFPlayerShared::RadiusCurrencyCollectionCheck( void )
 	{
 		if ( m_CurrencyPacks[i].hPack )
 		{
-			// If the timeout hits, force a touch
-			if ( m_CurrencyPacks[i].flTime <= gpGlobals->curtime )
-			{
-				m_CurrencyPacks[i].hPack->Touch( m_pOuter );
-			}
-			else
-			{
-				// Seek the player
-				const float flForce = 550.0f;
-
-				Vector vToPlayer = m_pOuter->GetAbsOrigin() - m_CurrencyPacks[i].hPack->GetAbsOrigin();
-
-				vToPlayer.z = 0.0f;
-				vToPlayer.NormalizeInPlace();
-				vToPlayer.z = 0.25f;
-
-				Vector vPush = flForce * vToPlayer;
-
-				m_CurrencyPacks[i].hPack->RemoveFlag( FL_ONGROUND );
-				m_CurrencyPacks[i].hPack->ApplyAbsVelocityImpulse( vPush );
-			}
+			m_CurrencyPacks[i].hPack->Touch( m_pOuter );
 		}
 		else
 		{


### PR DESCRIPTION
…adius (instead of it gravitating randomly toward him)

This is to prevent money from going randomly everywhere and, in some rare cases, to not be collected at all by the Scout.

This might be a bit out of scope on this project but I thought I'd make a PR anyway.