### PR TITLE
Fixed Medic Bots losing Uber if they pop before leaving spawn

### DIFF
--- a/game/server/tf/bot/behavior/tf_bot_behavior.cpp
+++ b/game/server/tf/bot/behavior/tf_bot_behavior.cpp
@@ -179,9 +179,7 @@ ActionResult< CTFBot >	CTFBotMainAction::Update( CTFBot *me, float interval )
 		if ( myArea && myArea->HasAttributeTF( spawnRoomFlag ) )
 		{
 			// invading bots get uber while they leave their spawn so they don't drop their cash where players can't pick it up
-			me->m_Shared.AddCond( TF_COND_INVULNERABLE, 0.5f );
 			me->m_Shared.AddCond( TF_COND_INVULNERABLE_HIDE_UNLESS_DAMAGED, 0.5f );
-			me->m_Shared.AddCond( TF_COND_INVULNERABLE_WEARINGOFF, 0.5f );
 		}
 
 		// watch for bots that have fallen through the ground


### PR DESCRIPTION
Robots now only add condition 51 when in spawn protection, rather than conditions 5+8+51.