### PR TITLE
VRAD: Fix thread-sharing bug

### DIFF
--- a/bitmap/float_bm4.cpp
+++ b/bitmap/float_bm4.cpp
@@ -20,7 +20,6 @@
 // In order to handle intersections with wrapped copies, we repeat the bitmap triangles this many
 // times
 #define NREPS_TILE 1
-extern int n_intersection_calculations;
 
 
 

--- a/raytrace/raytrace.cpp
+++ b/raytrace/raytrace.cpp
@@ -233,6 +233,10 @@ void CacheOptimizedTriangle::ChangeIntoIntersectionFormat(void)
 
 }
 
+#if _DEBUG
+std::atomic<int> n_intersection_calculations = 0;
+#endif
+
 int CacheOptimizedTriangle::ClassifyAgainstAxisSplit(int split_plane, float split_value)
 {
 	// classify a triangle against an axis-aligned plane
@@ -474,6 +478,10 @@ void RayTracingEnvironment::Trace4Rays(const FourRays &rays, fltx4 TMin, fltx4 T
 				TriIntersectData_t const *tri = &( OptimizedTriangleList[tnum].m_Data.m_IntersectData );
 				if ( ( mailboxids[mbox_slot] != tnum ) && ( tri->m_nTriangleID != skip_id ) )
 				{
+					#if _DEBUG
+					num_intersection_calculations++;
+					#endif
+					
 					mailboxids[mbox_slot] = tnum;
 					// compute plane intersection
 

--- a/raytrace/raytrace.cpp
+++ b/raytrace/raytrace.cpp
@@ -233,8 +233,6 @@ void CacheOptimizedTriangle::ChangeIntoIntersectionFormat(void)
 
 }
 
-int n_intersection_calculations=0;
-
 int CacheOptimizedTriangle::ClassifyAgainstAxisSplit(int split_plane, float split_value)
 {
 	// classify a triangle against an axis-aligned plane
@@ -476,7 +474,6 @@ void RayTracingEnvironment::Trace4Rays(const FourRays &rays, fltx4 TMin, fltx4 T
 				TriIntersectData_t const *tri = &( OptimizedTriangleList[tnum].m_Data.m_IntersectData );
 				if ( ( mailboxids[mbox_slot] != tnum ) && ( tri->m_nTriangleID != skip_id ) )
 				{
-					n_intersection_calculations++;
 					mailboxids[mbox_slot] = tnum;
 					// compute plane intersection
 

--- a/raytrace/raytrace.cpp
+++ b/raytrace/raytrace.cpp
@@ -479,7 +479,7 @@ void RayTracingEnvironment::Trace4Rays(const FourRays &rays, fltx4 TMin, fltx4 T
 				if ( ( mailboxids[mbox_slot] != tnum ) && ( tri->m_nTriangleID != skip_id ) )
 				{
 					#if _DEBUG
-					num_intersection_calculations++;
+					n_intersection_calculations++;
 					#endif
 					
 					mailboxids[mbox_slot] = tnum;


### PR DESCRIPTION
The raytracing code has debug variable `n_intersection_calculations`. This was used solely for debugging, but its existence caused a massive bottleneck in VRAD; performance nearly doubles on some systems without it.

More information and some performance testing can be found here: https://github.com/ValveSoftware/source-sdk-2013/pull/436