### PR TITLE
Added jpeglib to windows game solution being generated, so it can be …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,9 +94,7 @@ generated_proto*/
 !lib/common/win32/2015/release/binkw32.lib
 !lib/common/win32/2015/release/cryptlib.lib
 !lib/common/win32/2015/release/d3dx9.lib
-!lib/common/win32/2015/release/libjpeg.lib
-!lib/common/win32/2015/release/libpng.lib
-!lib/common/win32/2015/release/libjpeg.lib
+!lib/common/win32/2015/release/jpeglib.lib
 !lib/common/win32/2015/release/libpng.lib
 !lib/common/win32/2015/release/d3dx9.lib
 !lib/common/win32/2015/release/binkw32.lib

--- a/creategameprojects_dev.bat
+++ b/creategameprojects_dev.bat
@@ -1,2 +1,2 @@
-devtools\bin\vpc.exe /2015 /define:WORKSHOP_IMPORT_DISABLE /define:SIXENSE_DISABLE /define:NO_X360_XDK /define:RAD_TELEMETRY_DISABLED /define:DISABLE_ETW /define:LTCG /no_ceg /retail /define:CERT /nofpo /tf +game /mksln games.sln
+devtools\bin\vpc.exe +jpeglib /2015 /define:WORKSHOP_IMPORT_DISABLE /define:SIXENSE_DISABLE /define:NO_X360_XDK /define:RAD_TELEMETRY_DISABLED /define:DISABLE_ETW /define:LTCG /no_ceg /retail /define:CERT /nofpo /tf +game /mksln games.sln
 PAUSE

--- a/engine/engine.vpc
+++ b/engine/engine.vpc
@@ -1101,7 +1101,7 @@ $Project "engine"
 		$Lib	appframework
 		$Lib	bitmap
 		$Lib	"$LIBCOMMON/bzip2"
-		$Lib  	"$LIBCOMMON/libjpeg"			[!$DEDICATED]
+		$Lib  	"$LIBCOMMON/jpeglib"			[!$DEDICATED]
 
 		$Lib	dmxloader
 		$Lib	mathlib
@@ -1122,7 +1122,7 @@ $Project "engine"
 		// http://code.google.com/p/gperftools/wiki/GooglePerformanceTools
 		$File	"$SRCDIR/thirdparty/gperftools-2.0/.libs/libprofiler.so" [$GPROFILER]
 
-		$Lib	"$LIBCOMMON/binkw32"					[$WIN32&&!$QUICKTIME_WIN32]
+		//$Lib	"$LIBCOMMON/binkw32"					[$WIN32&&!$QUICKTIME_WIN32]
 		$File   "$LIBCOMMON\quicktime\QTMLClient"       [$WIN32&&$QUICKTIME_WIN32]
 		$ImpLib	"SDL2" [$SDL]
 		$File	"$SRCDIR\DX9SDK\lib\dsound.lib" [$WIN32]

--- a/game/client/client_econ_base.vpc
+++ b/game/client/client_econ_base.vpc
@@ -178,7 +178,7 @@ $Project
 	
 	$Folder	"Link Libraries" 
 	{
-		$Lib "$LIBCOMMON/libjpeg"
+		$Lib "$LIBCOMMON/jpeglib"
 		$Lib libpng [!$VS2015]
 		$Lib $LIBCOMMON/libpng [$VS2015]
 		$Lib libz

--- a/gameui/GameUI.vpc
+++ b/gameui/GameUI.vpc
@@ -248,7 +248,7 @@ $Project "GameUI"
 		$Lib	tier3
 		$Lib	vgui_controls
 		$Lib	vtf
-		$Lib  	"$LIBCOMMON/libjpeg"		[!$DEDICATED]
+		$Lib  	"$LIBCOMMON/jpeglib"		[!$DEDICATED]
 		$ImpLib	steam_api
 		$Lib libpng [!$VS2015&&!$DEDICATED]
 		$Lib $LIBCOMMON/libpng [$VS2015&&!$DEDICATED]

--- a/replay/replay.vpc
+++ b/replay/replay.vpc
@@ -197,7 +197,7 @@ $Project "replay"
 		$Lib	$LIBCOMMON\lzma
 		$Lib	vtf
 		$Lib	"$LIBCOMMON/bzip2"
-		$Lib  	"$LIBCOMMON/libjpeg"		[!$DEDICATED]
+		$Lib  	"$LIBCOMMON/jpeglib"		[!$DEDICATED]
 
 		$Libexternal	$LIBCOMMON/libcrypto [$OSXALL]
 		$Libexternal 	"$SRCDIR\lib\common\$(CRYPTOPPDIR)\libcrypto" [$LINUXALL]


### PR DESCRIPTION
…compiled easily.

Modified instances of "libjpeg.lib" in VPCs and in the gitignore, to "jpeglib.lib", as this is the name of the library when manually compiled.

Also removed the binkw32 lib dependency, it doesn't seem to be doing anything.