### PR TITLE
Show the pause menu when out of focus

### DIFF
--- a/engine/sys_mainwind.cpp
+++ b/engine/sys_mainwind.cpp
@@ -311,6 +311,9 @@ void CGame::AppActivate( bool fActive )
 			{
 				g_ClientDLL->IN_DeactivateMouse();
 			}
+
+			// Show the pause menu so the game releases our mouse correctly
+			Cbuf_AddText("gameui_activate");
 		}
 	}
 #endif // SWDS


### PR DESCRIPTION
Upon alt-tabbing from the game the mouse cursor will remain locked to the game window. This only happens while in game and not in the pause menu. As a fix for this I have made the pause menu display whenever the player unfocuses the window