### PR TITLE
More specific issue templates to lower the amount of out of scope or invalid issues being made

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: TC2 Bug report
-about: Create a report to help us improve
+about: Create a report for bugs that happen exclusively on TC2
 title: ''
 labels: 'Type: bug'
 assignees: mastercoms

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,11 +1,12 @@
 ---
-name: Bug report
+name: TC2 Bug report
 about: Create a report to help us improve
 title: ''
 labels: 'Type: bug'
 assignees: mastercoms
 
 ---
+**NOTE: Make sure this is a bug that only happens on Team Contress 2 and does not happen on vanilla TF2**
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: TC2 Bug report
 about: Create a report for bugs that happen exclusively on TC2
 title: ''
-labels: 'Type: bug'
+labels: bug, tc2 issue
 assignees: mastercoms
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,8 +6,8 @@ labels: 'Type: enhancement'
 assignees: mastercoms
 
 ---
-**NOTE:Features should NOT change the gameplay balance in a significant way and should NOT be purely cosmetic choices**
-Re-balancing and changing the games looks is OUT OF SCOPE. Ex. "Buff the Bison", "Bring back the beta muzzle flashes" would not be accepted
+**NOTE: Re-balancing and changing the game's looks is beyond the scope of this project.**
+Ex. "Buff the Bison", "Bring back the beta muzzle flashes" would not be accepted!
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,7 +6,7 @@ labels: 'Type: enhancement'
 assignees: mastercoms
 
 ---
-**NOTE:Make sure the feature being requested does NOT change the gameplay balance in a significant way and is NOT purely a cosmetic choice**
+**NOTE:Features should NOT change the gameplay balance in a significant way and should NOT be purely cosmetic choices**
 This project is not interested in re-balancing the game or changing its look. Ex. "Buff the Bison", "Bring back the beta muzzle flashes" would not be accepted
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,7 +7,7 @@ assignees: mastercoms
 
 ---
 **NOTE:Features should NOT change the gameplay balance in a significant way and should NOT be purely cosmetic choices**
-This project is not interested in re-balancing the game or changing its look. Ex. "Buff the Bison", "Bring back the beta muzzle flashes" would not be accepted
+Re-balancing and changing the games looks is OUT OF SCOPE. Ex. "Buff the Bison", "Bring back the beta muzzle flashes" would not be accepted
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,8 @@ labels: 'Type: enhancement'
 assignees: mastercoms
 
 ---
+**NOTE:Make sure the feature being requested does NOT change the gameplay balance in a significant way and is NOT purely a cosmetic choice**
+This poject is not interested in re-balancing the game or changing its looks. Ex. "Buff the Bison", "Bring back the beta muzzle flashes" would not be accepted
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,7 +7,7 @@ assignees: mastercoms
 
 ---
 **NOTE:Make sure the feature being requested does NOT change the gameplay balance in a significant way and is NOT purely a cosmetic choice**
-This poject is not interested in re-balancing the game or changing its looks. Ex. "Buff the Bison", "Bring back the beta muzzle flashes" would not be accepted
+This project is not interested in re-balancing the game or changing its look. Ex. "Buff the Bison", "Bring back the beta muzzle flashes" would not be accepted
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

--- a/.github/ISSUE_TEMPLATE/tf2_bug_fix_request.md
+++ b/.github/ISSUE_TEMPLATE/tf2_bug_fix_request.md
@@ -1,0 +1,30 @@
+---
+name: TF2 Bug Fix Request
+about: For bugs that happen on TF2 and should be patched on TC2
+title: ''
+labels: 'Type: tf2 issue'
+assignees: mastercoms
+
+---
+**NOTE: Make sure this is a bug that happens in normal Team Fortess 2 and STILL happens in TC2**
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**How you encountered the issue**
+Tell us the steps on how to recreate the bug.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+* Team Comtress version (don't say latest, say the actual version):
+* Custom content (if any):
+* DX level:
+* Launch options:
+* Operating system (OS):
+* Graphics card (GPU):
+* Graphics driver version:
+* Processor (CPU):
+* TF2 on HDD or SSD:
+* Memory (RAM) size in MB or GB:


### PR DESCRIPTION
I find that separating tf2 issues from TC2 bugs is useful because that is a common question asked in issues, also specified that "feature" does not mean balance patch or purely cosmetic changes