### PR TITLE
Fixed various issues relating to ragdoll/dissolve caused by weapons l…

### DIFF
--- a/game/server/tf/tf_player.cpp
+++ b/game/server/tf/tf_player.cpp
@@ -14882,7 +14882,36 @@ void CTFPlayer::CreateRagdollEntity( bool bGib, bool bBurning, bool bElectrocute
 		pRagdoll = NULL;
 	}
 	Assert( pRagdoll == NULL );
-
+	
+	auto player = reinterpret_cast<CTFPlayer *>(this);
+	
+	bool ClassHasDecentGibs(const CTFPlayer *pPlayer)
+	{
+		switch (pPlayer->GetPlayerClass()->GetClassIndex()) {
+		default:
+			return true;
+			
+		case TF_CLASS_ENGINEER: // no gibs
+		case TF_CLASS_MEDIC:    // head gib only
+		case TF_CLASS_SNIPER:   // head gib only
+		case TF_CLASS_SPY:      // head gib only
+			return false;
+		}
+	}
+	
+	CTFBot *bot;
+	if (TFGameRules()->IsMannVsMachineMode() && (bot = ToTFBot(player)) != nullptr) {
+		if (bot->IsMiniBoss() || bot->GetModelScale() > 1.0f) {
+			if (iDamageCustom == TF_DMG_CUSTOM_PLASMA) {
+				iDamageCustom = TF_DMG_CUSTOM_PLASMA_CHARGED;
+			}
+		} else {
+			if (iDamageCustom == TF_DMG_CUSTOM_PLASMA_CHARGED && !ClassHasDecentGibs(bot)) {
+				iDamageCustom = TF_DMG_CUSTOM_PLASMA;
+			}
+		}
+	}
+	
 	// Create a ragdoll.
 	pRagdoll = dynamic_cast<CTFRagdoll*>( CreateEntityByName( "tf_ragdoll" ) );
 	if ( pRagdoll )


### PR DESCRIPTION
…ike Cow Mangler and medigun shield

Problems:
1. TF_CUSTOM_PLASMA (Cow Mangler and medic shield) turns giants into
   small ragdolls that don't do the dissolving effect
2. TF_CUSTOM_PLASMA_CHARGED (Cow Mangler charged shot) makes robots gib,
   which looks silly for certain bot classes that only have 0-1 gibs

Solutions:
1. For giants, change PLASMA -> PLASMA_CHARGED
2. For classes missing gibs, change PLASMA_CHARGED -> PLASMA