### PR TITLE
Re-enable func_monitors and fix point_camera rendering

### DIFF
--- a/game/client/view.cpp
+++ b/game/client/view.cpp
@@ -51,7 +51,7 @@
 #include "replay/ienginereplay.h"
 #endif
 
-#if defined( HL2_CLIENT_DLL ) || defined( CSTRIKE_DLL )
+#if defined( HL2_CLIENT_DLL ) || defined( CSTRIKE_DLL ) || defined( TF_CLIENT_DLL )
 #define USE_MONITORS
 #endif
 

--- a/game/client/viewrender.cpp
+++ b/game/client/viewrender.cpp
@@ -59,7 +59,7 @@
 #include "portal_render_targets.h"
 #include "PortalRender.h"
 #endif
-#if defined( HL2_CLIENT_DLL ) || defined( CSTRIKE_DLL )
+#if defined( HL2_CLIENT_DLL ) || defined( CSTRIKE_DLL ) || defined( TF_CLIENT_DLL )
 #define USE_MONITORS
 #endif
 #include "rendertexture.h"

--- a/game/server/tf/tf_player.cpp
+++ b/game/server/tf/tf_player.cpp
@@ -10986,17 +10986,6 @@ void CTFPlayer::Event_KilledOther( CBaseEntity *pVictim, const CTakeDamageInfo &
 }
 
 //-----------------------------------------------------------------------------
-// Purpose: 
-//-----------------------------------------------------------------------------
-void CTFPlayer::SetupVisibility( CBaseEntity *pViewEntity, unsigned char *pvs, int pvssize )
-{
-	BaseClass::SetupVisibility( pViewEntity, pvs, pvssize );
-
-	int area = pViewEntity ? pViewEntity->NetworkProp()->AreaNum() : NetworkProp()->AreaNum();
-	PointCameraSetupVisibility( this, area, pvs, pvssize );
-}
-
-//-----------------------------------------------------------------------------
 // Purpose: Called on kill for primary and second-highest damage dealer
 //-----------------------------------------------------------------------------
 void CTFPlayer::OnKilledOther_Effects( CBaseEntity *pVictim, const CTakeDamageInfo &info )

--- a/game/server/tf/tf_player.cpp
+++ b/game/server/tf/tf_player.cpp
@@ -112,6 +112,8 @@
 #include "tf_player_resource.h"
 #include "gcsdk/gcclient_sharedobjectcache.h"
 #include "tf_party.h"
+#include "info_camera_link.h"
+#include "point_camera.h"
 #ifdef STAGING_ONLY
 #include "tf_extra_map_entity.h"
 #endif
@@ -3444,6 +3446,9 @@ int	CTFPlayer::ShouldTransmit( const CCheckTransmitInfo *pInfo )
 //-----------------------------------------------------------------------------
 void CTFPlayer::SetupVisibility( CBaseEntity *pViewEntity, unsigned char *pvs, int pvssize )
 {
+	int area = pViewEntity ? pViewEntity->NetworkProp()->AreaNum() : NetworkProp()->AreaNum();
+	PointCameraSetupVisibility( this, area, pvs, pvssize );
+
 	// coach can only "see" what the student "sees"
 	if ( m_bIsCoaching && m_hStudent )
 	{
@@ -10978,6 +10983,17 @@ void CTFPlayer::Event_KilledOther( CBaseEntity *pVictim, const CTakeDamageInfo &
 			SpeakConceptIfAllowed( MP_CONCEPT_KILLED_OBJECT, pObject->GetResponseRulesModifier() );
 		}
 	}
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CTFPlayer::SetupVisibility( CBaseEntity *pViewEntity, unsigned char *pvs, int pvssize )
+{
+	BaseClass::SetupVisibility( pViewEntity, pvs, pvssize );
+
+	int area = pViewEntity ? pViewEntity->NetworkProp()->AreaNum() : NetworkProp()->AreaNum();
+	PointCameraSetupVisibility( this, area, pvs, pvssize );
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
### Related Issue
This PR aims to fix two well know issue with [Func_monitor](https://developer.valvesoftware.com/wiki/Func_monitor) and [Point_camera](https://developer.valvesoftware.com/wiki/Point_camera)

### Solution
The solution was copying from [hl2_player](https://github.com/mastercomfig/team-comtress-2/blob/master/game/server/hl2/hl2_player.cpp#L1757), (it could be also from [cs_player](https://github.com/mastercomfig/team-comtress-2/blob/master/game/server/cstrike/cs_player.cpp#L1422) since both games support monitors) the next two lines of code:

```CPP
    int area = pViewEntity ? pViewEntity->NetworkProp()->AreaNum() : NetworkProp()->AreaNum();
    PointCameraSetupVisibility( this, area, pvs, pvssize );
```

### Screenshots
Sadly I cannot provide any screenshots since i don't had any map to test with it :S

### Checklist
- [X] This PR targets the `master` branch.
- [X] This bug has been filed as an issue.
- [X] No other PRs fix this bug.
- [X] This fix is as minimal as possible.
- [X] This fix does not introduce any regressions.
- [ ] This fix has been tested on all platforms, on both a dedicated server and on a listen server.


### Testing Checklist
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | X | X | -    |
|   Linux | X | X | - |
|  Mac OS | X | X | -      |

### Caveats
Nope, this don't bring any side effect that could break the game

### Alternatives
Nope