### PR TITLE
Revert sv_restrict_aspect_ratio_fov back to 1

### DIFF
--- a/engine/sv_main.cpp
+++ b/engine/sv_main.cpp
@@ -239,7 +239,7 @@ ConVar  sv_client_predict( "sv_client_predict", "-1", FCVAR_REPLICATED,
 	"    1 = force cl_predict to 1"
 	);
 
-ConVar  sv_restrict_aspect_ratio_fov( "sv_restrict_aspect_ratio_fov", "2", FCVAR_REPLICATED, 
+ConVar  sv_restrict_aspect_ratio_fov( "sv_restrict_aspect_ratio_fov", "1", FCVAR_REPLICATED, 
 									 "This can be used to limit the effective FOV of users using wide-screen\n"
 									 "resolutions with aspect ratios wider than 1.85:1 (slightly wider than 16:9).\n"
 									 "    0 = do not cap effective FOV\n"


### PR DESCRIPTION
This brings back Hor+ for 16:9> aspect ratios in fullscreen like in vanilla TF2.