### PR TITLE
fix various airblast projectile bugs

### DIFF
--- a/game/client/tf/hud_basedeathnotice.h
+++ b/game/client/tf/hud_basedeathnotice.h
@@ -54,7 +54,7 @@ struct DeathNoticeItem
 
 	DeathNoticePlayer	Killer;
 	DeathNoticePlayer   Victim;
-	char		szIcon[32];		// name of icon to display
+	char		szIcon[64];		// name of icon to display
 	wchar_t		wzInfoText[32];	// any additional text to display next to icon
 	wchar_t		wzInfoTextEnd[32];	// any additional text to display next to victim name
 	CHudTexture *iconDeath;

--- a/game/client/tf/tf_hud_deathnotice.cpp
+++ b/game/client/tf/tf_hud_deathnotice.cpp
@@ -985,13 +985,27 @@ void CTFHudDeathNotice::OnGameEvent( IGameEvent *event, int iDeathNoticeMsg )
 		case TF_DMG_CUSTOM_HEADSHOT_DECAPITATION:
 		case TF_DMG_CUSTOM_HEADSHOT:
 			{
-				if ( FStrEq( event->GetString( "weapon" ), "ambassador" ) )
+				const char *killer_weapon_name = event->GetString( "weapon" );
+
+				if ( 0 == Q_strcmp( killer_weapon_name, "ambassador" ) )
 				{
 					Q_strncpy( msg.szIcon, "d_ambassador_headshot", ARRAYSIZE( msg.szIcon ) );
 				}
-				else if ( FStrEq( event->GetString( "weapon" ), "huntsman" ) )
+				else if ( 0 == Q_strcmp( killer_weapon_name, "huntsman" ) )
 				{
 					Q_strncpy( msg.szIcon, "d_huntsman_headshot", ARRAYSIZE( msg.szIcon ) );
+				}
+				else if ( 0 == Q_strcmp( killer_weapon_name, "huntsman_flyingburn" ) )
+				{
+					Q_strncpy( msg.szIcon, "d_huntsman_flyingburn_headshot", ARRAYSIZE( msg.szIcon ) );
+				}
+				else if ( 0 == Q_strcmp( killer_weapon_name, "deflect_arrow" ) )
+				{
+					Q_strncpy( msg.szIcon, "d_deflect_huntsman_headshot", ARRAYSIZE( msg.szIcon ) );
+				}
+				else if ( 0 == Q_strcmp( killer_weapon_name, "deflect_huntsman_flyingburn" ) )
+				{
+					Q_strncpy( msg.szIcon, "d_deflect_huntsman_flyingburn_headshot", ARRAYSIZE( msg.szIcon ) );
 				}
 				else
 				{
@@ -1026,7 +1040,7 @@ void CTFHudDeathNotice::OnGameEvent( IGameEvent *event, int iDeathNoticeMsg )
 
 		case TF_DMG_CUSTOM_FLYINGBURN:
 			// special-case if the player is killed from a burning arrow as the killing blow
-			Q_strncpy( msg.szIcon, "d_huntsman_flyingburn", ARRAYSIZE( msg.szIcon ) );
+			Q_strncpy( msg.szIcon, 0 == Q_strcmp( event->GetString( "weapon" ), "deflect_huntsman_flyingburn" ) ? "d_deflect_huntsman_flyingburn" : "d_huntsman_flyingburn", ARRAYSIZE( msg.szIcon ) );
 			msg.wzInfoText[0] = 0;
 			break;
 

--- a/game/server/tf/tf_projectile_arrow.cpp
+++ b/game/server/tf/tf_projectile_arrow.cpp
@@ -578,7 +578,7 @@ bool CTFProjectile_Arrow::StrikeTarget( mstudiobbox_t *pBox, CBaseEntity *pOther
 					}
 				}
 
-				CTakeDamageInfo info( this, pAttacker, m_hLauncher, vecVelocity, vecOrigin, GetDamage(), nDamageType, nDamageCustom );
+				CTakeDamageInfo info( this, pAttacker, GetOriginalLauncher(), vecVelocity, vecOrigin, GetDamage(), nDamageType, nDamageCustom );
 				pOther->TakeDamage( info );
 
 				// Play an impact sound.
@@ -1210,6 +1210,8 @@ void CTFProjectile_Arrow::IncrementDeflected( void )
 		m_flTrailLife = 1.0f;
 	}
 	CreateTrail();
+
+	m_nSkin = GetArrowSkin();
 }
 
 //-----------------------------------------------------------------------------

--- a/game/server/tf/tf_projectile_arrow.cpp
+++ b/game/server/tf/tf_projectile_arrow.cpp
@@ -714,7 +714,7 @@ void CTFProjectile_Arrow::BuildingHealingArrow( CBaseEntity *pOther )
 		return;
 
 	int iArrowsHealBuildings = 0;
-	CALL_ATTRIB_HOOK_INT_ON_OTHER( pAttacker, iArrowsHealBuildings, arrow_heals_buildings );
+	CALL_ATTRIB_HOOK_INT_ON_OTHER( GetOriginalLauncher(), iArrowsHealBuildings, arrow_heals_buildings );
 	if ( iArrowsHealBuildings == 0 )
 		return;
 

--- a/game/server/tf/tf_projectile_flare.cpp
+++ b/game/server/tf/tf_projectile_flare.cpp
@@ -207,7 +207,8 @@ void CTFProjectile_Flare::Explode( trace_t *pTrace, CBaseEntity *pOther )
 
 	CTFPlayer *pTFVictim = ToTFPlayer( pOther );
 
-	CTFFlareGun *pFlareGun = dynamic_cast< CTFFlareGun* >( GetLauncher() );
+	CBaseEntity *pLauncher = GetOriginalLauncher();
+	CTFFlareGun *pFlareGun = dynamic_cast< CTFFlareGun* >( pLauncher );
 	if ( pFlareGun )
 	{
 		if ( pFlareGun->GetFlareGunType() == FLAREGUN_SCORCHSHOT )
@@ -228,7 +229,7 @@ void CTFProjectile_Flare::Explode( trace_t *pTrace, CBaseEntity *pOther )
 				iDamageType |= DMG_PREVENT_PHYSICS_FORCE;
 
 				// Damage the player to push them back
-				CTakeDamageInfo info( this, pAttacker, m_hLauncher, vec3_origin, vecOrigin, GetDamage(), iDamageType, m_bIsFromTaunt ? TF_DMG_CUSTOM_FLARE_PELLET : 0 );
+				CTakeDamageInfo info( this, pAttacker, pLauncher, vec3_origin, vecOrigin, GetDamage(), iDamageType, m_bIsFromTaunt ? TF_DMG_CUSTOM_FLARE_PELLET : TF_DMG_CUSTOM_BURNING_FLARE );
 				pTFVictim->TakeDamage( info );
 
 				bool bIsEnemy = pAttacker && pTFVictim->GetTeamNumber() != pAttacker->GetTeamNumber();
@@ -329,7 +330,7 @@ void CTFProjectile_Flare::Explode( trace_t *pTrace, CBaseEntity *pOther )
 		m_bCritical = true;
 	}
 
-	CTakeDamageInfo info( this, pAttacker, m_hLauncher, vec3_origin, vecOrigin, GetDamage(), GetDamageType(), TF_DMG_CUSTOM_BURNING_FLARE );
+	CTakeDamageInfo info( this, pAttacker, pLauncher, vec3_origin, vecOrigin, GetDamage(), GetDamageType(), TF_DMG_CUSTOM_BURNING_FLARE );
 	pOther->TakeDamage( info );
 
 	// Remove the flare.

--- a/game/server/tf/tf_projectile_flare.cpp
+++ b/game/server/tf/tf_projectile_flare.cpp
@@ -606,6 +606,8 @@ void CTFProjectile_Flare::Deflected( CBaseEntity *pDeflectedBy, Vector &vecDir )
 
 	IncrementDeflected();
 	SetScorer( pTFDeflector );
+	
+	m_nSkin = ( GetTeamNumber() == TF_TEAM_BLUE ) ? 1 : 0;
 }
 
 float CTFProjectile_Flare::GetProjectileSpeed( void ) const

--- a/game/shared/tf/tf_gamerules.cpp
+++ b/game/shared/tf/tf_gamerules.cpp
@@ -11699,11 +11699,12 @@ const char *CTFGameRules::GetKillingWeaponName( const CTakeDamageInfo &info, CTF
  	CBaseEntity *pInflictor = info.GetInflictor();
 	CBaseEntity *pKiller = info.GetAttacker();
 	CBasePlayer *pScorer = GetDeathScorer( pKiller, pInflictor, pVictim );
+	int iDamageCustom = info.GetDamageCustom();
 
 	const char *killer_weapon_name = "world";
 	*iWeaponID = TF_WEAPON_NONE;
 
-	if ( info.GetDamageCustom() == TF_DMG_CUSTOM_BURNING )
+	if ( iDamageCustom == TF_DMG_CUSTOM_BURNING )
 	{
 		// special-case burning damage, since persistent burning damage may happen after attacker has switched weapons
 		killer_weapon_name = "tf_weapon_flamethrower";
@@ -11720,7 +11721,7 @@ const char *CTFGameRules::GetKillingWeaponName( const CTakeDamageInfo &info, CTF
 			}
 		}
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_BURNING_FLARE )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_BURNING_FLARE )
 	{
 		// special-case burning damage, since persistent burning damage may happen after attacker has switched weapons
 		killer_weapon_name = "tf_weapon_flaregun";
@@ -11750,7 +11751,7 @@ const char *CTFGameRules::GetKillingWeaponName( const CTakeDamageInfo &info, CTF
 			}
 		}
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_FLARE_EXPLOSION )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_FLARE_EXPLOSION )
 	{
 		killer_weapon_name = "tf_weapon_detonator";
 		*iWeaponID = TF_WEAPON_FLAREGUN;
@@ -11767,7 +11768,7 @@ const char *CTFGameRules::GetKillingWeaponName( const CTakeDamageInfo &info, CTF
 			}
 		}
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_CHARGE_IMPACT )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_CHARGE_IMPACT )
 	{
 		CTFWearable *pWearable = dynamic_cast< CTFWearable * >( info.GetWeapon() );
 		if ( pWearable )
@@ -11785,44 +11786,44 @@ const char *CTFGameRules::GetKillingWeaponName( const CTakeDamageInfo &info, CTF
 		// This may be stomped later if the kill was a headshot.
 		killer_weapon_name = "player_penetration";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_PICKAXE )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_PICKAXE )
 	{
 		killer_weapon_name = "pickaxe";
 		*iWeaponID = TF_WEAPON_SHOVEL;
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_CARRIED_BUILDING )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_CARRIED_BUILDING )
 	{
 		killer_weapon_name = "tf_weapon_building_carried_destroyed";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_TAUNTATK_HADOUKEN )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_TAUNTATK_HADOUKEN )
 	{
 		killer_weapon_name = "tf_weapon_taunt_pyro";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_TAUNTATK_HIGH_NOON )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_TAUNTATK_HIGH_NOON )
 	{
 		killer_weapon_name = "tf_weapon_taunt_heavy";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_TAUNTATK_GRAND_SLAM )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_TAUNTATK_GRAND_SLAM )
 	{
 		killer_weapon_name = "tf_weapon_taunt_scout";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_TAUNTATK_BARBARIAN_SWING )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_TAUNTATK_BARBARIAN_SWING )
 	{
 		killer_weapon_name = "tf_weapon_taunt_demoman";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_TAUNTATK_UBERSLICE )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_TAUNTATK_UBERSLICE )
 	{
 		killer_weapon_name = "tf_weapon_taunt_medic";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_TAUNTATK_FENCING )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_TAUNTATK_FENCING )
 	{
 		killer_weapon_name = "tf_weapon_taunt_spy";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_TAUNTATK_ARROW_STAB )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_TAUNTATK_ARROW_STAB )
 	{
 		killer_weapon_name = "tf_weapon_taunt_sniper";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_TAUNTATK_GRENADE )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_TAUNTATK_GRENADE )
 	{
 		CTFPlayer *pTFKiller = ToTFPlayer( pKiller );
 		if ( pTFKiller && pTFKiller->IsWormsGearEquipped() )
@@ -11834,39 +11835,44 @@ const char *CTFGameRules::GetKillingWeaponName( const CTakeDamageInfo &info, CTF
 			killer_weapon_name = "tf_weapon_taunt_soldier";
 		}
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_TAUNTATK_ENGINEER_GUITAR_SMASH )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_TAUNTATK_ENGINEER_GUITAR_SMASH )
 	{
 		killer_weapon_name = "tf_weapon_taunt_guitar_kill";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_TAUNTATK_ALLCLASS_GUITAR_RIFF )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_TAUNTATK_ALLCLASS_GUITAR_RIFF )
 	{
 		killer_weapon_name = "tf_weapon_taunt_guitar_riff_kill";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_TAUNTATK_ENGINEER_ARM_KILL )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_TAUNTATK_ENGINEER_ARM_KILL )
 	{
 		killer_weapon_name = "robot_arm_blender_kill";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_TELEFRAG )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_TELEFRAG )
 	{
 		killer_weapon_name = "telefrag";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_BOOTS_STOMP )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_BOOTS_STOMP )
 	{
 		killer_weapon_name = "mantreads";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_BASEBALL )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_BASEBALL )
 	{
 		killer_weapon_name = "ball";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_COMBO_PUNCH )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_CLEAVER ||
+			  iDamageCustom == TF_DMG_CUSTOM_CLEAVER_CRIT )			// Throwables
+	{
+		killer_weapon_name = "guillotine";
+	}
+	else if ( iDamageCustom == TF_DMG_CUSTOM_COMBO_PUNCH )
 	{
 		killer_weapon_name = "robot_arm_combo_kill";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_BLEEDING )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_BLEEDING )
 	{
 		killer_weapon_name = "tf_weapon_bleed_kill";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_PLAYER_SENTRY )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_PLAYER_SENTRY )
 	{
 		int nGigerCounter = 0; 
 		if ( pScorer )
@@ -11883,88 +11889,88 @@ const char *CTFGameRules::GetKillingWeaponName( const CTakeDamageInfo &info, CTF
 			killer_weapon_name = "wrangler_kill";
 		}
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_DECAPITATION_BOSS )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_DECAPITATION_BOSS )
 	{
 		killer_weapon_name = "headtaker";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_EYEBALL_ROCKET )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_EYEBALL_ROCKET )
 	{
 		killer_weapon_name = "eyeball_rocket";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_STICKBOMB_EXPLOSION )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_STICKBOMB_EXPLOSION )
 	{
 		killer_weapon_name = "ullapool_caber_explosion";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_TAUNTATK_ARMAGEDDON )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_TAUNTATK_ARMAGEDDON )
 	{
 		killer_weapon_name = "armageddon";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_SAPPER_RECORDER_DEATH )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_SAPPER_RECORDER_DEATH )
 	{
 		killer_weapon_name = "recorder";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_MERASMUS_DECAPITATION )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_MERASMUS_DECAPITATION )
 	{
 		killer_weapon_name = "merasmus_decap";
 	}	
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_MERASMUS_ZAP )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_MERASMUS_ZAP )
 	{
 		killer_weapon_name = "merasmus_zap";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_MERASMUS_GRENADE )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_MERASMUS_GRENADE )
 	{
 		killer_weapon_name = "merasmus_grenade";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_MERASMUS_PLAYER_BOMB )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_MERASMUS_PLAYER_BOMB )
 	{
 		killer_weapon_name = "merasmus_player_bomb";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_CANNONBALL_PUSH )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_CANNONBALL_PUSH )
 	{
 		killer_weapon_name = "loose_cannon_impact";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_SPELL_TELEPORT )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_SPELL_TELEPORT )
 	{
 		killer_weapon_name = "spellbook_teleport";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_SPELL_SKELETON )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_SPELL_SKELETON )
 	{
 		killer_weapon_name = "spellbook_skeleton";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_SPELL_MIRV )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_SPELL_MIRV )
 	{
 		killer_weapon_name = "spellbook_mirv";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_SPELL_METEOR )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_SPELL_METEOR )
 	{
 		killer_weapon_name = "spellbook_meteor";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_SPELL_LIGHTNING )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_SPELL_LIGHTNING )
 	{
 		killer_weapon_name = "spellbook_lightning";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_SPELL_FIREBALL )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_SPELL_FIREBALL )
 	{
 		killer_weapon_name = "spellbook_fireball";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_SPELL_MONOCULUS )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_SPELL_MONOCULUS )
 	{
 		killer_weapon_name = "spellbook_boss";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_SPELL_BLASTJUMP )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_SPELL_BLASTJUMP )
 	{
 		killer_weapon_name = "spellbook_blastjump";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_SPELL_BATS )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_SPELL_BATS )
 	{
 		killer_weapon_name = "spellbook_bats";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_SPELL_TINY )
+	else if ( iDamageCustom == TF_DMG_CUSTOM_SPELL_TINY )
 	{
 		killer_weapon_name = "spellbook_athletic";
 	}
-	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_THROWABLE ||
-			  info.GetDamageCustom() == TF_DMG_CUSTOM_THROWABLE_KILL )			// Throwables
+	else if ( iDamageCustom == TF_DMG_CUSTOM_THROWABLE ||
+			  iDamageCustom == TF_DMG_CUSTOM_THROWABLE_KILL )			// Throwables
 	{
 		if ( pVictim && pVictim->GetHealth() <= 0 )
 		{
@@ -12067,7 +12073,7 @@ const char *CTFGameRules::GetKillingWeaponName( const CTakeDamageInfo &info, CTF
 		}
 	}
 
-	if ( info.GetDamageCustom() == TF_DMG_CUSTOM_DEFENSIVE_STICKY )
+	if ( iDamageCustom == TF_DMG_CUSTOM_DEFENSIVE_STICKY )
 	{
 		killer_weapon_name = "sticky_resistance";
 	}
@@ -12187,7 +12193,7 @@ const char *CTFGameRules::GetKillingWeaponName( const CTakeDamageInfo &info, CTF
 			}
 		}
 	}
-	else if ( ( info.GetDamageCustom() == TF_DMG_CUSTOM_STANDARD_STICKY ) || ( info.GetDamageCustom() == TF_DMG_CUSTOM_AIR_STICKY_BURST ) )
+	else if ( ( iDamageCustom == TF_DMG_CUSTOM_STANDARD_STICKY ) || ( iDamageCustom == TF_DMG_CUSTOM_AIR_STICKY_BURST ) )
 	{
 		// let's look-up the secondary weapon to see what type of sticky launcher it is
 		if ( pScorer )

--- a/game/shared/tf/tf_gamerules.cpp
+++ b/game/shared/tf/tf_gamerules.cpp
@@ -11731,12 +11731,9 @@ const char *CTFGameRules::GetKillingWeaponName( const CTakeDamageInfo &info, CTF
 		{
 			CTFBaseRocket *pBaseRocket = dynamic_cast<CTFBaseRocket*>( pInflictor );
 
-			if ( pBaseRocket )
+			if ( pBaseRocket && pBaseRocket->GetDeflected() )
 			{
-				if ( pBaseRocket->GetDeflected() )
-				{
-					killer_weapon_name = "deflect_flare";
-				}
+				killer_weapon_name = "deflect_flare";
 			}
 		}
 
@@ -11759,12 +11756,9 @@ const char *CTFGameRules::GetKillingWeaponName( const CTakeDamageInfo &info, CTF
 		if ( pInflictor && pInflictor->IsPlayer() == false )
 		{
 			CTFBaseRocket *pBaseRocket = dynamic_cast<CTFBaseRocket*>( pInflictor );
-			if ( pBaseRocket )
+			if ( pBaseRocket && pBaseRocket->GetDeflected() )
 			{
-				if ( pBaseRocket->GetDeflected() )
-				{
-					killer_weapon_name = "deflect_flare";
-				}
+				killer_weapon_name = "deflect_flare";
 			}
 		}
 	}
@@ -11862,12 +11856,9 @@ const char *CTFGameRules::GetKillingWeaponName( const CTakeDamageInfo &info, CTF
 		if ( pInflictor && pInflictor->IsPlayer() == false )
 		{
 			CTFWeaponBaseGrenadeProj *pBaseGrenade = dynamic_cast<CTFWeaponBaseGrenadeProj*>( pInflictor );
-			if ( pBaseGrenade )
+			if ( pBaseGrenade && pBaseGrenade->GetDeflected() )
 			{
-				if ( pBaseGrenade->GetDeflected() )
-				{
-					killer_weapon_name = "deflect_ball";
-				}
+				killer_weapon_name = "deflect_ball";
 			}
 		}
 	}
@@ -12052,6 +12043,18 @@ const char *CTFGameRules::GetKillingWeaponName( const CTakeDamageInfo &info, CTF
 				else if ( *iWeaponID == TF_WEAPON_ROCKETLAUNCHER_DIRECTHIT )
 				{
 					killer_weapon_name = "rocketlauncher_directhit";
+				}
+				else if ( *iWeaponID == TF_WEAPON_COMPOUND_BOW )
+				{
+					CTFProjectile_Arrow* pArrow = dynamic_cast<CTFProjectile_Arrow*>( pBaseRocket );
+					if ( pArrow && pArrow->IsAlight() )
+					{
+						killer_weapon_name = "huntsman_flyingburn";
+
+						// force death notice to use burning arrow headshot kill icon
+						if ( iDamageCustom == TF_DMG_CUSTOM_HEADSHOT )
+							*iWeaponID = TF_WEAPON_NONE;
+					}
 				}
 			}
 			else

--- a/game/shared/tf/tf_gamerules.cpp
+++ b/game/shared/tf/tf_gamerules.cpp
@@ -11763,7 +11763,7 @@ const char *CTFGameRules::GetKillingWeaponName( const CTakeDamageInfo &info, CTF
 			{
 				if ( pBaseRocket->GetDeflected() )
 				{
-					killer_weapon_name = "deflect_flare_detonator";
+					killer_weapon_name = "deflect_flare";
 				}
 			}
 		}

--- a/game/shared/tf/tf_gamerules.cpp
+++ b/game/shared/tf/tf_gamerules.cpp
@@ -11858,9 +11858,21 @@ const char *CTFGameRules::GetKillingWeaponName( const CTakeDamageInfo &info, CTF
 	else if ( iDamageCustom == TF_DMG_CUSTOM_BASEBALL )
 	{
 		killer_weapon_name = "ball";
+
+		if ( pInflictor && pInflictor->IsPlayer() == false )
+		{
+			CTFWeaponBaseGrenadeProj *pBaseGrenade = dynamic_cast<CTFWeaponBaseGrenadeProj*>( pInflictor );
+			if ( pBaseGrenade )
+			{
+				if ( pBaseGrenade->GetDeflected() )
+				{
+					killer_weapon_name = "deflect_ball";
+				}
+			}
+		}
 	}
 	else if ( iDamageCustom == TF_DMG_CUSTOM_CLEAVER ||
-			  iDamageCustom == TF_DMG_CUSTOM_CLEAVER_CRIT )			// Throwables
+			  iDamageCustom == TF_DMG_CUSTOM_CLEAVER_CRIT )
 	{
 		killer_weapon_name = "guillotine";
 	}

--- a/game/shared/tf/tf_weapon_bat.cpp
+++ b/game/shared/tf/tf_weapon_bat.cpp
@@ -1252,8 +1252,7 @@ void CTFBall_Ornament::VPhysicsCollisionThink( void )
 void CTFBall_Ornament::Explode( trace_t *pTrace, int bitsDamageType )
 {
 	// Create smashed glass particles when we explode
-	CTFPlayer* pOwner = ToTFPlayer( GetOwnerEntity() );
-	if ( pOwner && pOwner->GetTeamNumber() == TF_TEAM_RED )
+	if ( GetTeamNumber() == TF_TEAM_RED )
 	{
 		DispatchParticleEffect( "xms_ornament_smash_red", GetAbsOrigin(), GetAbsAngles() );
 	}
@@ -1262,6 +1261,7 @@ void CTFBall_Ornament::Explode( trace_t *pTrace, int bitsDamageType )
 		DispatchParticleEffect( "xms_ornament_smash_blue", GetAbsOrigin(), GetAbsAngles() );
 	}
 
+	CTFPlayer* pOwner = ToTFPlayer( GetOwnerEntity() );
 	Vector vecOrigin = GetAbsOrigin();
 
 	// sound effects

--- a/game/shared/tf/tf_weapon_bat.cpp
+++ b/game/shared/tf/tf_weapon_bat.cpp
@@ -669,23 +669,7 @@ void CTFStunBall::Spawn( void )
 	SetContextThink( &CBaseEntity::SUB_Remove, gpGlobals->curtime + 15, "DieContext" );
 
 	// Draw the trail for the Baseball on spawn
-	if ( !m_pBallTrail )
-	{
-		const char *pTrailTeamName = ( GetTeamNumber() == TF_TEAM_RED ) ? "effects/baseballtrail_red.vmt" : "effects/baseballtrail_blu.vmt";
-		CSpriteTrail *pTempTrail = NULL;
-
-		pTempTrail = CSpriteTrail::SpriteTrailCreate( pTrailTeamName, GetAbsOrigin(), true );
-		pTempTrail->FollowEntity( this );
-		pTempTrail->SetTransparency( kRenderTransAlpha, 255, 255, 255, STUNBALL_TRAIL_ALPHA, kRenderFxNone );
-		pTempTrail->SetStartWidth( 9 );
-		pTempTrail->SetTextureResolution( 1.0f / ( 96.0f * 1.0f ) );
-		pTempTrail->SetLifeTime( 0.4 );
-		pTempTrail->TurnOn();
-		pTempTrail->SetAttachment( this, 0 );
-		m_pBallTrail = pTempTrail;
-		SetContextThink( &CTFStunBall::RemoveBallTrail, gpGlobals->curtime + 3, "FadeBallTrail");
-	}
-
+	CreateBallTrail();
 }
 
 //-----------------------------------------------------------------------------
@@ -916,6 +900,29 @@ void CTFStunBall::VPhysicsCollision( int index, gamevcollisionevent_t *pEvent )
 }
 
 //-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CTFStunBall::CreateBallTrail( void )
+{
+	if ( m_pBallTrail )
+		return;
+	
+	const char *pTrailTeamName = ( GetTeamNumber() == TF_TEAM_RED ) ? "effects/baseballtrail_red.vmt" : "effects/baseballtrail_blu.vmt";
+	CSpriteTrail *pTempTrail = NULL;
+
+	pTempTrail = CSpriteTrail::SpriteTrailCreate( pTrailTeamName, GetAbsOrigin(), true );
+	pTempTrail->FollowEntity( this );
+	pTempTrail->SetTransparency( kRenderTransAlpha, 255, 255, 255, STUNBALL_TRAIL_ALPHA, kRenderFxNone );
+	pTempTrail->SetStartWidth( 9 );
+	pTempTrail->SetTextureResolution( 1.0f / ( 96.0f * 1.0f ) );
+	pTempTrail->SetLifeTime( 0.4 );
+	pTempTrail->TurnOn();
+	pTempTrail->SetAttachment( this, 0 );
+	m_pBallTrail = pTempTrail;
+	SetContextThink( &CTFStunBall::RemoveBallTrail, gpGlobals->curtime + 3, "FadeBallTrail");
+}
+
+//-----------------------------------------------------------------------------
 // Purpose: Fade and kill the trail
 //-----------------------------------------------------------------------------
 void CTFStunBall::RemoveBallTrail( void )
@@ -945,6 +952,23 @@ void CTFStunBall::RemoveBallTrail( void )
 			SetContextThink( &CTFStunBall::RemoveBallTrail, gpGlobals->curtime + 0.05, "FadeBallTrail");
 		}
 	}
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Ball was deflected.
+//-----------------------------------------------------------------------------
+void CTFStunBall::IncrementDeflected( void )
+{
+	BaseClass::IncrementDeflected();
+
+	// Change trail color.
+	if ( m_pBallTrail )
+	{
+		UTIL_Remove( m_pBallTrail );
+		m_pBallTrail = NULL;
+		m_flBallTrailLife = 1.0f;
+	}
+	CreateBallTrail();
 }
 
 // -- SERVER ONLY

--- a/game/shared/tf/tf_weapon_bat.cpp
+++ b/game/shared/tf/tf_weapon_bat.cpp
@@ -785,19 +785,11 @@ void CTFStunBall::ApplyBallImpactEffectOnVictim( CBaseEntity *pOther )
 	const trace_t *pTrace = &CBaseEntity::GetTouchTrace();
 	trace_t *pNewTrace = const_cast<trace_t*>( pTrace );
 
-	CBaseEntity *pInflictor = GetLauncher();
-	CTakeDamageInfo info;
-	info.SetAttacker( GetOwnerEntity() );
-	info.SetInflictor( pInflictor ); 
-	info.SetWeapon( pInflictor );
-	info.SetDamage( flDamage );
-	info.SetDamageCustom( TF_DMG_CUSTOM_BASEBALL );
-	info.SetDamageForce( GetDamageForce() );
-	info.SetDamagePosition( GetAbsOrigin() );
 	int iDamageType = GetDamageType();
 	if ( IsCritical() )
 		iDamageType |= DMG_CRITICAL;
-	info.SetDamageType( iDamageType );
+	
+	CTakeDamageInfo info( this, GetThrower(), GetOriginalLauncher(), GetDamageForce(), GetAbsOrigin(), flDamage, iDamageType, TF_DMG_CUSTOM_BASEBALL );
 
 	// Hurt 'em.
 	Vector dir;
@@ -1161,7 +1153,9 @@ void CTFBall_Ornament::ApplyBallImpactEffectOnVictim( CBaseEntity *pOther )
 
 	// just do the bleed effect directly since the bleed
 	// attribute comes from the inflictor, which is the bat.
-	pPlayer->m_Shared.MakeBleed( pOwner, (CTFBat_Giftwrap *)GetLauncher(), flBleedTime );
+	CBaseEntity *pThrower = GetThrower();
+	CBaseEntity *pLauncher = GetOriginalLauncher();
+	pPlayer->m_Shared.MakeBleed( ToTFPlayer( pThrower ), (CTFBat_Giftwrap *)pLauncher, flBleedTime );
 
 	// Apply particle effect to victim (the remaining effects happen inside Explode)
 	DispatchParticleEffect( "xms_ornament_glitter", PATTACH_POINT_FOLLOW, pPlayer, "head" );
@@ -1170,19 +1164,11 @@ void CTFBall_Ornament::ApplyBallImpactEffectOnVictim( CBaseEntity *pOther )
 	const trace_t *pTrace = &CBaseEntity::GetTouchTrace();
 	trace_t *pNewTrace = const_cast<trace_t*>( pTrace );
 
-	CBaseEntity *pInflictor = GetLauncher();
-	CTakeDamageInfo info;
-	info.SetAttacker( GetOwnerEntity() );
-	info.SetInflictor( pInflictor ); 
-	info.SetWeapon( pInflictor );
-	info.SetDamage( GetDamage() );
-	info.SetDamageCustom( TF_DMG_CUSTOM_BASEBALL );
-	info.SetDamageForce( GetDamageForce() );
-	info.SetDamagePosition( GetAbsOrigin() );
 	int iDamageType = GetDamageType();
 	if ( bIsCriticalHit )
 		iDamageType |= DMG_CRITICAL;
-	info.SetDamageType( iDamageType );
+	
+	CTakeDamageInfo info( this, pThrower, pLauncher, GetDamageForce(), GetAbsOrigin(), GetDamage(), iDamageType, TF_DMG_CUSTOM_BASEBALL );
 
 	// Hurt 'em.
 	Vector dir;
@@ -1294,7 +1280,7 @@ void CTFBall_Ornament::Explode( trace_t *pTrace, int bitsDamageType )
 
 	// Do radius damage
 	Vector vecBlastForce(0.0f, 0.0f, 0.0f);
-	CTakeDamageInfo info( this, GetThrower(), m_hLauncher, vecBlastForce, GetAbsOrigin(), flExplodeDamage, bitsDamageType, TF_DMG_CUSTOM_BASEBALL, &vecOrigin );
+	CTakeDamageInfo info( this, GetThrower(), GetOriginalLauncher(), vecBlastForce, GetAbsOrigin(), flExplodeDamage, bitsDamageType, TF_DMG_CUSTOM_BASEBALL, &vecOrigin );
 	CTFRadiusDamageInfo radiusinfo( &info, vecOrigin, DEFAULT_ORNAMENT_EXPLODE_RADIUS, nullptr, 0.0f, 0.0f );
 	TFGameRules()->RadiusDamage( radiusinfo );
 

--- a/game/shared/tf/tf_weapon_bat.cpp
+++ b/game/shared/tf/tf_weapon_bat.cpp
@@ -1145,7 +1145,7 @@ void CTFBall_Ornament::ApplyBallImpactEffectOnVictim( CBaseEntity *pOther )
 
 	// long distance hit is always a crit
 	float flLifeTime = gpGlobals->curtime - m_flCreationTime;
-	if ( flLifeTime >= FLIGHT_TIME_TO_MAX_STUN )
+	if ( flLifeTime >= FLIGHT_TIME_TO_MAX_STUN * 0.8f )
 	{
 		bIsCriticalHit = true;
 		bIsLongRangeHit = true;

--- a/game/shared/tf/tf_weapon_bat.h
+++ b/game/shared/tf/tf_weapon_bat.h
@@ -160,7 +160,11 @@ public:
 
 	virtual float		GetShakeAmplitude( void )			{ return 0.0; }
 	virtual float		GetShakeRadius( void )				{ return 0.0; }
+
+	void				CreateBallTrail( void );
 	void				RemoveBallTrail( void );
+	
+	virtual void		IncrementDeflected( void );
 	
 	virtual bool		IsDestroyable( void ) OVERRIDE { return false; }
 

--- a/game/shared/tf/tf_weapon_jar.cpp
+++ b/game/shared/tf/tf_weapon_jar.cpp
@@ -1015,19 +1015,21 @@ void CTFProjectile_Cleaver::OnHit( CBaseEntity *pOther )
 	if ( TFGameRules() && TFGameRules()->IsTruceActive() && pOwner->IsTruceValidForEnt() )
 		return;
 
+	CBaseEntity *pLauncher = GetOriginalLauncher();
 	bool bIsCriticalHit = IsCritical();
-	bool bIsMiniCrit = false;
 	float flBleedTime = 5.0f;
-
+	
 	float flLifeTime = gpGlobals->curtime - m_flCreationTime;
-	if ( flLifeTime >= FLIGHT_TIME_TO_MAX_DMG )
+	if ( flLifeTime >= FLIGHT_TIME_TO_MAX_DMG * 0.5f )
 	{
-		bIsMiniCrit = true;
+		// Reduce 1.5 seconds of charge time for long-range hits
+		auto pWeapon = dynamic_cast< CTFWeaponBase* >( pLauncher );
+		if ( pWeapon && pWeapon->HasEffectBarRegeneration() )
+			pWeapon->DecrementBarRegenTime( 1.5f );
 	}
 
 	// just do the bleed effect directly since the bleed
 	// attribute comes from the inflictor, which is the cleaver.
-	CBaseEntity *pLauncher = GetOriginalLauncher();
 	pPlayer->m_Shared.MakeBleed( pOwner, (CTFCleaver *)pLauncher, flBleedTime );
 
 	// Give 'em a love tap.
@@ -1038,7 +1040,7 @@ void CTFProjectile_Cleaver::OnHit( CBaseEntity *pOther )
 	if ( bIsCriticalHit )
 		iDamageType |= DMG_CRITICAL;
 	
-	CTakeDamageInfo info( this, pOwner, pLauncher, GetDamage(), iDamageType, bIsMiniCrit ? TF_DMG_CUSTOM_CLEAVER_CRIT : TF_DMG_CUSTOM_CLEAVER );
+	CTakeDamageInfo info( this, pOwner, pLauncher, GetDamage(), iDamageType, TF_DMG_CUSTOM_CLEAVER );
 	info.SetDamagePosition( GetAbsOrigin() );
 
 	// Hurt 'em.

--- a/game/shared/tf/tf_weapon_jar.cpp
+++ b/game/shared/tf/tf_weapon_jar.cpp
@@ -1018,7 +1018,7 @@ void CTFProjectile_Cleaver::OnHit( CBaseEntity *pOther )
 	CBaseEntity *pLauncher = GetOriginalLauncher();
 	bool bIsCriticalHit = IsCritical();
 	float flBleedTime = 5.0f;
-	
+
 	float flLifeTime = gpGlobals->curtime - m_flCreationTime;
 	if ( flLifeTime >= FLIGHT_TIME_TO_MAX_DMG * 0.5f )
 	{

--- a/game/shared/tf/tf_weapon_jar.cpp
+++ b/game/shared/tf/tf_weapon_jar.cpp
@@ -1027,26 +1027,19 @@ void CTFProjectile_Cleaver::OnHit( CBaseEntity *pOther )
 
 	// just do the bleed effect directly since the bleed
 	// attribute comes from the inflictor, which is the cleaver.
-	pPlayer->m_Shared.MakeBleed( pOwner, (CTFCleaver *)GetLauncher(), flBleedTime );
+	CBaseEntity *pLauncher = GetOriginalLauncher();
+	pPlayer->m_Shared.MakeBleed( pOwner, (CTFCleaver *)pLauncher, flBleedTime );
 
 	// Give 'em a love tap.
 	const trace_t *pTrace = &CBaseEntity::GetTouchTrace();
 	trace_t *pNewTrace = const_cast<trace_t*>( pTrace );
 
-	CBaseEntity *pInflictor = GetLauncher();
-	CTakeDamageInfo info;
-	info.SetAttacker( pOwner );
-	info.SetInflictor( pInflictor ); 
-	info.SetWeapon( pInflictor );
-	info.SetDamage( GetDamage() );
-	info.SetDamageCustom( bIsMiniCrit ? TF_DMG_CUSTOM_CLEAVER_CRIT : TF_DMG_CUSTOM_CLEAVER );
-	info.SetDamagePosition( GetAbsOrigin() );
 	int iDamageType = GetDamageType();
 	if ( bIsCriticalHit )
-	{
 		iDamageType |= DMG_CRITICAL;
-	}
-	info.SetDamageType( iDamageType );
+	
+	CTakeDamageInfo info( this, pOwner, pLauncher, GetDamage(), iDamageType, bIsMiniCrit ? TF_DMG_CUSTOM_CLEAVER_CRIT : TF_DMG_CUSTOM_CLEAVER );
+	info.SetDamagePosition( GetAbsOrigin() );
 
 	// Hurt 'em.
 	Vector dir;


### PR DESCRIPTION
fixes the following bugs from the official tf2 wiki:
* [Sandman](https://wiki.teamfortress.com/wiki/Sandman#Bugs): When an enemy Pyro blasts the ball and it hits a friendly player, they are slowed, but are not damaged by it. 
* [Wrap Assassin](https://wiki.teamfortress.com/wiki/Wrap_Assassin#Bugs): If a player is hit by a friendly Scout's ornament that was deflected by an enemy Pyro, that player will not be inflicted with bleeding, even though the bleed icon and visual effects appear on the HUD and the screen respectively.
* [Rescue Ranger](https://wiki.teamfortress.com/wiki/Rescue_Ranger#Bugs): Reflected bolts from Pyros do not heal buildings.
* [Scorch Shot](https://wiki.teamfortress.com/wiki/Compression_blast#Bugs): Reflected flares from the Scorch Shot will not inflict radius damage upon hitting a non-player surface.

implements unused projectile kill icons:
* reflect kill with stunball/ornament
* reflect kill with cleaver
* reflect kill with flare (scorch shot and detonator)
* reflect kill with arrow headshot
* reflect kill with burning arrow
* reflect kill with burning arrow headshot

fixes the following not using the correct team colour when reflected:
* shattered ornament particle effect
* stunball trail
* ornament trail
* flare skin
* crossbow bolt skin
* repair bolt skin

changes from Jungle Inferno:
* flight time for ornament to crit reduced by 20% (to match sandman change: https://github.com/mastercomfig/team-comtress-2/commit/8abc3d2dcf2819c18b4bf2c133452156d13701d4)
* long-range cleaver hits no longer mini-crit, gives 1.5 s of charge instead
* flight time for cleaver to reward charge is halved

### Caveats
- probably a bit messy that all of these barely-related changes are in the same pr
- the string length for kill icon names has been increased to 64 from 32 so the icon for headshot kills with a reflected burning huntsman arrow can be displayed, because its icon name is too long: "d_deflect_huntsman_flyingburn_headshot"
- kills with a reflected ornament will gib players if they have only a few points of health
- exacerbates this issue: https://github.com/mastercomfig/team-comtress-2/issues/120 (instead of only affecting rockets, grenades, and flares, it will also affect balls, cleavers, and arrows)

### Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [ ] This PR does not introduce any regressions.
- [x] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | yes | yes | 8.1 |