### PR TITLE
Disable zombie souls for sentry busters

### DIFF
--- a/game/server/tf/bot/tf_bot.cpp
+++ b/game/server/tf/bot/tf_bot.cpp
@@ -4553,6 +4553,14 @@ void CTFBot::AddItem( const char* pszItemName )
 	criteria.SetQuality( AE_USE_SCRIPT_VALUE );
 	criteria.BAddCondition( "name", k_EOperator_String_EQ, pszItemName, true );
 
+	if ( strncmp( pszItemName, "Zombie ", strlen("Zombie ")) == 0 ) )
+	{
+		if ( this->m_Objective == CTFBot::MISSION_DESTROY_SENTRIES ) 
+		{
+			return;
+		}
+	}
+		
 	CBaseEntity *pItem = ItemGeneration()->GenerateRandomItem( &criteria, WorldSpaceCenter(), vec3_angle );
 	if ( pItem )
 	{


### PR DESCRIPTION
Prevents graphical issues

### Related Issue
<!-- Number of the issue where this bug was filed -->

### Implementation
<!-- A clear and concise description of what the changes are -->

### Screenshots
<!-- Add screenshots if applicable -->

### Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
- [ ] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [ ] No other PRs address this.
- [ ] This PR is as minimal as possible.
- [ ] This PR does not introduce any regressions.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
<!-- Any caveats and side effects of this PR -->

### Alternatives
<!-- Alternatives that were considered -->
