### PR TITLE
Restore functionality to tf_parachute_maxspeed_onfire_z but set its value to match tf_parachute_maxspeed_z

### DIFF
--- a/game/shared/tf/tf_gamemovement.cpp
+++ b/game/shared/tf/tf_gamemovement.cpp
@@ -52,7 +52,7 @@ ConVar	tf_max_charge_speed( "tf_max_charge_speed", "750", FCVAR_NOTIFY | FCVAR_R
 ConVar  tf_parachute_gravity( "tf_parachute_gravity", "0.2f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Gravity while parachute is deployed" );
 ConVar  tf_parachute_maxspeed_xy( "tf_parachute_maxspeed_xy", "400.0f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Max XY Speed while Parachute is deployed" );
 ConVar  tf_parachute_maxspeed_z( "tf_parachute_maxspeed_z", "-100.0f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Max Z Speed while Parachute is deployed" );
-ConVar  tf_parachute_maxspeed_onfire_z( "tf_parachute_maxspeed_onfire_z", "10.0f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Max Z Speed when on Fire and Parachute is deployed" );
+ConVar  tf_parachute_maxspeed_onfire_z( "tf_parachute_maxspeed_onfire_z", "-100.0f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Max Z Speed when on Fire and Parachute is deployed" );
 ConVar  tf_parachute_aircontrol( "tf_parachute_aircontrol", "2.5f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Multiplier for how much air control players have when Parachute is deployed" );
 
 ConVar  tf_halloween_kart_aircontrol( "tf_halloween_kart_aircontrol", "1.2f", FCVAR_CHEAT | FCVAR_REPLICATED, "Multiplier for how much air control players have when in Kart Mode" );
@@ -2594,7 +2594,7 @@ void CTFGameMovement::FullWalkMove()
 	{
 		if ( m_pTFPlayer->m_Shared.InCond( TF_COND_PARACHUTE_DEPLOYED ) && mv->m_vecVelocity[2] < 0 )
 		{
-			mv->m_vecVelocity[2] = Max( mv->m_vecVelocity[2], tf_parachute_maxspeed_z.GetFloat() );
+			mv->m_vecVelocity[2] = Max( mv->m_vecVelocity[2], m_pTFPlayer->m_Shared.InCond( TF_COND_BURNING ) ? tf_parachute_maxspeed_onfire_z.GetFloat() : tf_parachute_maxspeed_z.GetFloat() );
 			
 			float flDrag = tf_parachute_maxspeed_xy.GetFloat();
 			// Instead of clamping, we'll dampen


### PR DESCRIPTION
This allows servers to restore the original functionality with a value of '10.0f' (or whatever other value they desire)

### Related Issue
N/A

### Implementation
Adds a ternary check for TF_COND_BURNING with the two convar values as the true/false conditions. This matches the implementation

### Screenshots
N/A

### Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
- [Y] This PR targets the `master` branch.
- [N] This change has been filed as an issue.
- [Y] No other PRs address this.
- [Y] This PR is as minimal as possible.
- [?] This PR does not introduce any regressions.
- [N] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
Untested on any platforms, but this is exactly what the `CTFGameMovement::FullWalkMove` method did in ~Sept. 2015.

### Caveats
Server operators may not know that '10.0f' is the value to use to get the old behavior and there's no good way to give them that information.

### Alternatives
Considered adding new cvar to enable/disable this feature but instead opted to use the existing cvars.
