### PR TITLE
.bat: Don't pause on CI

### DIFF
--- a/creategameprojects.bat
+++ b/creategameprojects.bat
@@ -1,2 +1,2 @@
 devtools\bin\vpc.exe /2015 /define:WORKSHOP_IMPORT_DISABLE /define:SIXENSE_DISABLE /define:NO_X360_XDK /define:RAD_TELEMETRY_DISABLED /define:DISABLE_ETW /define:LTCG /no_ceg /retail /define:CERT /tf +game /mksln games.sln
-@PAUSE
+@IF NOT DEFINED CI PAUSE

--- a/creategameprojects_debug.bat
+++ b/creategameprojects_debug.bat
@@ -1,2 +1,2 @@
 devtools\bin\vpc.exe /2015 /define:WORKSHOP_IMPORT_DISABLE /define:SIXENSE_DISABLE /define:NO_X360_XDK /define:RAD_TELEMETRY_DISABLED /define:DISABLE_ETW /no_ceg /nofpo /tf +game /mksln games.sln
-@PAUSE
+@IF NOT DEFINED CI PAUSE

--- a/creategameprojects_dev.bat
+++ b/creategameprojects_dev.bat
@@ -1,2 +1,2 @@
 devtools\bin\vpc.exe /2015 /define:WORKSHOP_IMPORT_DISABLE /define:SIXENSE_DISABLE /define:NO_X360_XDK /define:RAD_TELEMETRY_DISABLED /define:DISABLE_ETW /define:LTCG /no_ceg /retail /define:CERT /nofpo /tf +game /mksln games.sln
-@PAUSE
+@IF NOT DEFINED CI PAUSE

--- a/download_libs.bat
+++ b/download_libs.bat
@@ -4,4 +4,4 @@
 (for %%l in (%libs%) do (
    curl %server%%%l -Lo %%l --create-dirs
 ))
-@PAUSE
+@IF NOT DEFINED CI PAUSE


### PR DESCRIPTION
### Related Issue

### Implementation
Reduces console spam (`Press any key to continue . . . `) and stops AppVeyor (and possibly other CI) from hanging.

### Screenshots

### Checklist
- [ ] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [ ] No other PRs address this.
- [ ] This PR is as minimal as possible.
- [ ] This PR does not introduce any regressions.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats

### Alternatives
