### PR TITLE
add "start" and "exit" so that cmd closes

### DIFF
--- a/game_clean/hl2.bat
+++ b/game_clean/hl2.bat
@@ -1,3 +1,2 @@
 @echo off
-start hl2.exe -steam -game tf -insecure %*
-exit
+@start hl2.exe -steam -game tf -insecure %*

--- a/game_clean/hl2.bat
+++ b/game_clean/hl2.bat
@@ -1,2 +1,3 @@
 @echo off
-hl2.exe -steam -game tf -insecure %*
+start hl2.exe -steam -game tf -insecure %*
+exit


### PR DESCRIPTION
right now CMD opens and then only closes when TC2 closes, this simple edit makes CMD close as soon as its done. currently the CMD window flashes for a second, i'll look into hiding the window alongside just closing it

### Implementation
add `@start` right before `hl2.exe`

### Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Caveats
CMD opens and then immediately closes, causing it to flicker on screen.

### Alternatives
None
