### PR TITLE
Fixing a handful of race conditions

### DIFF
--- a/datacache/mdlcache.cpp
+++ b/datacache/mdlcache.cpp
@@ -81,7 +81,7 @@ namespace {
 #if defined( _X360 )
 #define AsyncMdlCache() 0	// Explicitly OFF for 360 (incompatible)
 #else
-#define AsyncMdlCache() 1
+#define AsyncMdlCache() 0
 #endif
 
 #define ERROR_MODEL		"models/error.mdl"

--- a/engine/audio/private/snd_dma.cpp
+++ b/engine/audio/private/snd_dma.cpp
@@ -69,7 +69,7 @@ extern IVideoServices *g_pVideo;
 #define SNDLVL_TO_DIST_MULT( sndlvl ) ( sndlvl ? ((pow( 10.0f, snd_refdb.GetFloat() / 20 ) / pow( 10.0f, (float)sndlvl / 20 )) / snd_refdist.GetFloat()) : 0 )
 #define DIST_MULT_TO_SNDLVL( dist_mult ) (soundlevel_t)(int)( dist_mult ? ( 20 * log10( pow( 10.0f, snd_refdb.GetFloat() / 20 ) / (dist_mult * snd_refdist.GetFloat()) ) ) : 0 )
 
-#define THREADED_SOUND_UPDATE
+//#define THREADED_SOUND_UPDATE
 
 extern ConVar dsp_spatial;
 extern IPhysicsSurfaceProps	*physprop;
@@ -6789,7 +6789,6 @@ void S_Update_Thread()
 	while ( !g_bMixThreadExit )
 	{
 		const double t0 = Plat_FloatTime();
-		S_Update_New();
 		S_Update_Guts(frameTime + snd_mixahead.GetFloat());
 		const double tf = Plat_FloatTime();
 

--- a/tier0/threadtools.cpp
+++ b/tier0/threadtools.cpp
@@ -1349,7 +1349,7 @@ void CThreadSpinRWLock::LockForRead()
 	LockInfo_t oldValue;
 	LockInfo_t newValue;
 
-	oldValue.m_nReaders = m_lockInfo.load().m_nReaders;
+	oldValue.m_nReaders = m_lockInfo.m_nReaders;
 	oldValue.m_writerId = 0;
 	newValue.m_nReaders = oldValue.m_nReaders + 1;
 	newValue.m_writerId = 0;
@@ -1357,7 +1357,7 @@ void CThreadSpinRWLock::LockForRead()
 	if( m_nWriters == 0 && AssignIf( newValue, oldValue ) )
 		return;
 	ThreadPause();
-	oldValue.m_nReaders = m_lockInfo.load().m_nReaders;
+	oldValue.m_nReaders = m_lockInfo.m_nReaders;
 	newValue.m_nReaders = oldValue.m_nReaders + 1;
 
 	for ( i = 1000; i != 0; --i )
@@ -1365,7 +1365,7 @@ void CThreadSpinRWLock::LockForRead()
 		if( m_nWriters == 0 && AssignIf( newValue, oldValue ) )
 			return;
 		ThreadPause();
-		oldValue.m_nReaders = m_lockInfo.load().m_nReaders;
+		oldValue.m_nReaders = m_lockInfo.m_nReaders;
 		newValue.m_nReaders = oldValue.m_nReaders + 1;
 	}
 
@@ -1375,7 +1375,7 @@ void CThreadSpinRWLock::LockForRead()
 			return;
 		ThreadPause();
 		ThreadSleep( 0 );
-		oldValue.m_nReaders = m_lockInfo.load().m_nReaders;
+		oldValue.m_nReaders = m_lockInfo.m_nReaders;
 		newValue.m_nReaders = oldValue.m_nReaders + 1;
 	}
 
@@ -1385,7 +1385,7 @@ void CThreadSpinRWLock::LockForRead()
 			return;
 		ThreadPause();
 		ThreadSleep( 1 );
-		oldValue.m_nReaders = m_lockInfo.load().m_nReaders;
+		oldValue.m_nReaders = m_lockInfo.m_nReaders;
 		newValue.m_nReaders = oldValue.m_nReaders + 1;
 	}
 }
@@ -1394,11 +1394,11 @@ void CThreadSpinRWLock::UnlockRead()
 {
 	int i;
 
-	Assert( m_lockInfo.load().m_nReaders > 0 && m_lockInfo.load().m_writerId == 0 );
+	Assert( m_lockInfo.m_nReaders > 0 && m_lockInfo.m_writerId == 0 );
 	LockInfo_t oldValue;
 	LockInfo_t newValue;
 
-	oldValue.m_nReaders = m_lockInfo.load().m_nReaders;
+	oldValue.m_nReaders = m_lockInfo.m_nReaders;
 	oldValue.m_writerId = 0;
 	newValue.m_nReaders = oldValue.m_nReaders - 1;
 	newValue.m_writerId = 0;
@@ -1406,7 +1406,7 @@ void CThreadSpinRWLock::UnlockRead()
 	if( AssignIf( newValue, oldValue ) )
 		return;
 	ThreadPause();
-	oldValue.m_nReaders = m_lockInfo.load().m_nReaders;
+	oldValue.m_nReaders = m_lockInfo.m_nReaders;
 	newValue.m_nReaders = oldValue.m_nReaders - 1;
 
 	for ( i = 500; i != 0; --i )
@@ -1414,7 +1414,7 @@ void CThreadSpinRWLock::UnlockRead()
 		if( AssignIf( newValue, oldValue ) )
 			return;
 		ThreadPause();
-		oldValue.m_nReaders = m_lockInfo.load().m_nReaders;
+		oldValue.m_nReaders = m_lockInfo.m_nReaders;
 		newValue.m_nReaders = oldValue.m_nReaders - 1;
 	}
 
@@ -1424,7 +1424,7 @@ void CThreadSpinRWLock::UnlockRead()
 			return;
 		ThreadPause();
 		ThreadSleep( 0 );
-		oldValue.m_nReaders = m_lockInfo.load().m_nReaders;
+		oldValue.m_nReaders = m_lockInfo.m_nReaders;
 		newValue.m_nReaders = oldValue.m_nReaders - 1;
 	}
 
@@ -1434,14 +1434,14 @@ void CThreadSpinRWLock::UnlockRead()
 			return;
 		ThreadPause();
 		ThreadSleep( 1 );
-		oldValue.m_nReaders = m_lockInfo.load().m_nReaders;
+		oldValue.m_nReaders = m_lockInfo.m_nReaders;
 		newValue.m_nReaders = oldValue.m_nReaders - 1;
 	}
 }
 
 void CThreadSpinRWLock::UnlockWrite()
 {
-	Assert( m_lockInfo.load().m_writerId == ThreadGetCurrentId()  && m_lockInfo.load().m_nReaders == 0 );
+	Assert( m_lockInfo.m_writerId == ThreadGetCurrentId()  && m_lockInfo.m_nReaders == 0 );
 	static const LockInfo_t newValue = { 0, 0 };
 #if defined(_X360)
 	// X360TBD: Serious Perf implications, not yet. __sync();


### PR DESCRIPTION
### Related Issue
<!-- Number of the issue where this bug was filed -->

### Implementation
Reverting changes for stability.
#323 CThreadSpinRWLock::UnlockWrite Assertion Failed 
#332 CJob::Execute Assertion Failed 
#333 CEngineTraceClient::GetWorldCollideable Assertion Failed 

### Screenshots
<!-- Add screenshots if applicable -->

### Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
- [x] This PR targets the `master` branch.
- [x] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | x | <!-- Built, Tested or N/A --> | Windows 7    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
Back to original perf until a proper fix is made.

### Alternatives

