### PR TITLE
download_libs: Consistency

### DIFF
--- a/download_libs_linux.sh
+++ b/download_libs_linux.sh
@@ -4,5 +4,5 @@ server="https://libs.mastercomfig.com/"
 
 for lib in "${libs[@]}"
 do
-  curl "${server}${lib}" -o "${lib}"
+  curl "${server}${lib}" -Lo "${lib}" --create-dirs
 done

--- a/download_libs_mac.sh
+++ b/download_libs_mac.sh
@@ -4,5 +4,5 @@ server="https://libs.mastercomfig.com/"
 
 for lib in "${libs[@]}"
 do
-  curl "${server}${lib}" -o "${lib}"
+  curl "${server}${lib}" -Lo "${lib}" --create-dirs
 done


### PR DESCRIPTION
### Related Issue

### Implementation
download_libs_linux/mac.sh now use the same arguments as download_libs.bat for consistency.

I was thinking of adding `-C -` so libs don't needlessly get redownloaded and interrupted downloads are resumable, but I'm not sure if it verifies files or not, and corrupt or outdated libs would have to be deleted manually.

### Screenshots

### Checklist
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats

### Alternatives
