### PR TITLE
Enable DXMath for all platforms

### DIFF
--- a/public/mathlib/mathlib.h
+++ b/public/mathlib/mathlib.h
@@ -22,12 +22,10 @@
 #include <xmmintrin.h>
 #endif
 
-#ifdef PLATFORM_WINDOWS_PC
 #define USE_DIRECTX_MATH
 #include "../thirdparty/DirectXMath-apr2020/Inc/DirectXMath.h"
 #define VectorLoad( Ptr ) DirectX::XMLoadFloat4( (const DirectX::XMFLOAT4*)(Ptr) )
 #define VectorStore( Vec, Ptr )	DirectX::XMStoreFloat4((DirectX::XMFLOAT4*)(Ptr), Vec )
-#endif
 
 // XXX remove me
 #undef clamp


### PR DESCRIPTION
Currently, linux builds on master fail due to missing DXMath vector functions, due to this include not being included. SInce DXmath is already being used there, this shouldn't break anything.

### Related Issue
N/A

### Implementation
This enables the DXMath include on all platforms by removing a windows `#ifdef`.

### Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | N/A | N/A | N/A  |
|   Linux | Built | Built | `5.8.10-lqx1-1-lqx #1 ZEN SMP PREEMPT Thu, 17 Sep 2020 14:35:33 +0000` |
|  Mac OS | Not available | Not available | N/A |

### Caveats
Any linux dxmath bugs will now show up.

### Alternatives
Enable & fix SIMD math on linux.
