### PR TITLE
Fix DX9ex usage on ToGL

### DIFF
--- a/materialsystem/shaderapidx9/shaderdevicedx8.cpp
+++ b/materialsystem/shaderapidx9/shaderdevicedx8.cpp
@@ -1870,7 +1870,7 @@ void CShaderDeviceDx8::ShutdownDevice()
 //-----------------------------------------------------------------------------
 bool CShaderDeviceDx8::IsUsingGraphics() const
 {
-	//*****LOCK_SHADERAPI();
+	//!!!!!LOCK_SHADERAPI();
 	return IsActive();
 }
 
@@ -2410,10 +2410,12 @@ bool CShaderDeviceDx8::CreateD3DDevice( void* pHWnd, int nAdapter, const ShaderD
 
 	g_pHardwareConfig->SetupHardwareCaps( info, g_ShaderDeviceMgrDx8.GetHardwareCaps( nAdapter ) );
 
+#ifndef DX_TO_GL_ABSTRACTION
 	if (g_ShaderDeviceUsingD3D9Ex)
 	{
 		Dx9ExDevice()->SetMaximumFrameLatency(1);
 	}
+#endif
 
 	// FIXME: Bake this into hardware config
 	// What texture formats do we support?
@@ -3401,10 +3403,12 @@ void CShaderDeviceDx8::Present()
 		{
 			bValidPresent = false;
 		}
+#ifndef DX_TO_GL_ABSTRACTION
 		if (bValidPresent && g_ShaderDeviceUsingD3D9Ex)
 		{
 			Dx9ExDevice()->SetGPUThreadPriority(7);
 		}
+#endif
 	}
 	// Copy the back buffer into the non-interactive temp buffer
 	if ( m_NonInteractiveRefresh.m_Mode == MATERIAL_NON_INTERACTIVE_MODE_LEVEL_LOAD )
@@ -3442,12 +3446,14 @@ void CShaderDeviceDx8::Present()
 		else
 		{
 			g_pShaderAPI->OwnGPUResources( false );
+#ifndef DX_TO_GL_ABSTRACTION
 			if (g_ShaderDeviceUsingD3D9Ex)
 			{
 				int flags = D3DPRESENT_DONOTWAIT;
 				hr = Dx9ExDevice()->PresentEx(0, 0, 0, 0, flags);
 			}
 			else
+#endif
 			{
 				hr = Dx9Device()->Present(0, 0, 0, 0);
 			}

--- a/materialsystem/shaderapidx9/shaderdevicedx8.h
+++ b/materialsystem/shaderapidx9/shaderdevicedx8.h
@@ -360,12 +360,7 @@ FORCEINLINE IDirect3DDevice9 *Dx9Device()
 {
 	return g_pD3DDevice;
 }
-#ifdef DX_TO_GL_ABSTRACTION
-FORCEINLINE IDirect3DDevice9Ex* Dx9ExDevice()
-{
-	return NULL;
-}
-#else
+#ifndef DX_TO_GL_ABSTRACTION
 FORCEINLINE IDirect3DDevice9Ex* Dx9ExDevice()
 {
 	return (IDirect3DDevice9Ex*)g_pD3DDevice;


### PR DESCRIPTION
### Related Issue
N/A

### Implementation
This PR puts `#ifndef DX_TO_GL_ABSTRACTION` around new d3d9ex function usages, because d3d9ex functions are not implemented in ToGL, which causes builds to error on platforms that use ToGL (linux, macos).

### Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Should not affect | N/A | N/A    |
|   Linux | Built | N/A | `5.8.10-lqx1-1-lqx #1 ZEN SMP PREEMPT Thu, 17 Sep 2020 14:35:33 +0000` |
|  Mac OS | Unavailable | N/A | N/A      |

### Caveats
ToGL platforms will not be able to enjoy dx9ex optimizations.

### Alternatives
Implement dx9ex into ToGL.
