### PR TITLE
Switch to C++17 in Linux base Makefile

### DIFF
--- a/devtools/makefile_base_posix.mak
+++ b/devtools/makefile_base_posix.mak
@@ -81,7 +81,7 @@ ENV_CFLAGS := $(CFLAGS)
 ENV_CXXFLAGS := $(CXXFLAGS)
 CPPFLAGS = $(DEFINES) $(addprefix -I, $(abspath $(INCLUDEDIRS) ))
 BASE_CFLAGS = $(ARCH_FLAGS) $(CPPFLAGS) $(WARN_FLAGS) -fvisibility=$(SymbolVisibility) $(OptimizerLevel) -pipe $(GCC_ExtraCompilerFlags) -Usprintf -Ustrncpy -UPROTECTED_THINGS_ENABLE
-BASE_CXXFLAGS = -std=c++11
+BASE_CXXFLAGS = -std=c++17
 # Additional CXXFLAGS when compiling PCH files
 PCH_CXXFLAGS =
 


### PR DESCRIPTION
### Related Issue
N/A

### Implementation
The base `CXXFLAGS` has `-std=c++11` set. This PR changes it to `-std=c++17`.

### Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | N/A | N/A | N/A    |
|   Linux | Built | Built | `5.8.10-lqx1-1-lqx #1 ZEN SMP PREEMPT Thu, 17 Sep 2020 14:35:33 +0000` |
|  Mac OS | N/A | N/A | N/A |

### Caveats
New/added C++ code will have to be C++17 compliant. (Already required anyways)

### Alternatives
Revert to c++11
