### PR TITLE
Backport point_spotlight SetColor & ForceUpdate

### DIFF
--- a/game/server/point_spotlight.cpp
+++ b/game/server/point_spotlight.cpp
@@ -46,6 +46,8 @@ private:
 	// ------------------------------
 	void InputLightOn( inputdata_t &inputdata );
 	void InputLightOff( inputdata_t &inputdata );
+    void InputSetColor( inputdata_t &inputdata );
+    void InputForceUpdate( inputdata_t &inputdata ); 
 
 	// Creates the efficient spotlight 
 	void CreateEfficientSpotlight();
@@ -98,6 +100,9 @@ BEGIN_DATADESC( CPointSpotlight )
 	// Inputs
 	DEFINE_INPUTFUNC( FIELD_VOID,		"LightOn",		InputLightOn ),
 	DEFINE_INPUTFUNC( FIELD_VOID,		"LightOff",		InputLightOff ),
+    DEFINE_INPUTFUNC( FIELD_COLOR32,    "SetColor",     InputSetColor ),
+    DEFINE_INPUTFUNC( FIELD_VOID,       "ForceUpdate",  InputForceUpdate ),
+
 	DEFINE_OUTPUT( m_OnOn, "OnLightOn" ),
 	DEFINE_OUTPUT( m_OnOff, "OnLightOff" ),
 
@@ -528,4 +533,24 @@ void CPointSpotlight::InputLightOff( inputdata_t &inputdata )
 			SpotlightDestroy();
 		}
 	}
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Set the beam's color
+//-----------------------------------------------------------------------------
+void CPointSpotlight::InputSetColor( inputdata_t &inputdata )
+{
+    if ( m_hSpotlight )
+    {
+        color32 clr = inputdata.value.Color32();
+        m_hSpotlight->SetColor( clr.r, clr.g, clr.b );
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Force update the spotlight
+//-----------------------------------------------------------------------------
+void CPointSpotlight::InputForceUpdate( inputdata_t &inputdata )
+{
+    SpotlightUpdate();
 }


### PR DESCRIPTION
### Related Issue
#345

### Implementation
Backported point_spotlight SetColor & ForceUpdate, backwards compatible with standard TF2.

### Screenshots
https://youtu.be/z2t_GruN0jw

### Checklist
- [x] This PR targets the `master` branch.
- [x] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Built, Tested | N/A | Windows 10    |
|   Linux | N/A | N/A | N/A |
|  Mac OS | N/A | N/A | N/A      |