### PR TITLE
Rework CTFPlayer::CanAirDash (double jumps)

### DIFF
--- a/game/shared/tf/tf_player_shared.cpp
+++ b/game/shared/tf/tf_player_shared.cpp
@@ -12152,26 +12152,18 @@ bool CTFPlayer::CanAirDash( void ) const
 	if ( m_Shared.InCond( TF_COND_HALLOWEEN_SPEED_BOOST ) )
 		return true;
 
-	bool bScout = GetPlayerClass()->IsClass( TF_CLASS_SCOUT );
-	if ( !bScout )
-		return false;
+	int iNoAirDash = 0;
+	CALL_ATTRIB_HOOK_INT( iNoAirDash, set_scout_doublejump_disabled );
+
+	int iDashCount = ( !iNoAirDash && GetPlayerClass()->IsClass( TF_CLASS_SCOUT ) ) ? tf_scout_air_dash_count.GetInt() : 0;
 
 	if ( m_Shared.InCond( TF_COND_SODAPOPPER_HYPE ) )
 	{
-		if ( m_Shared.GetAirDash() < 5 )
-			return true;
-		else
- 			return false;
+		iDashCount += 4;
 	}
 
-	int iDashCount = tf_scout_air_dash_count.GetInt();
 	CALL_ATTRIB_HOOK_INT( iDashCount, air_dash_count );
 	if ( m_Shared.GetAirDash() >= iDashCount ) 
-		return false;
-
-	int iNoAirDash = 0;
-	CALL_ATTRIB_HOOK_INT( iNoAirDash, set_scout_doublejump_disabled );
-	if ( 1 == iNoAirDash )
 		return false;
 
 	return true;


### PR DESCRIPTION
This changes the requirements for a given class/player to air dash:
Halloween Speed Boost condition allows air dash at all times for any class (unchanged)
All classes may air dash if they have nonzero air dash count
Scouts have base air dash count dictated by tf_scout_air_dash_count, other classes have 0
set_scout_doublejump_disabled attribute nullifies the effect of tf_scout_air_dash_count
Soda Popper Hype adds 4 to air dash count
air_dash_count attribute further adds to air dash count, increasing the number of dashes available

Differences from current:
set_scout_doublejump_disabled previously disabled air dashes entirely unless the player had Halloween Speed Boost or Soda Popper Hype, now it only disables the base air dash count that Scouts get
Soda Popper and the air_dash_count attribute allow any class to gain air dashes
This should function identically to current on a stock server (where players cannot obtain Hype or air_dash_count if they are not a Scout, and cannot obtain set_scout_doublejump_disabled at all since it was removed from the Sandman)
set_scout_doublejump_disabled previously only had any effect with a value of exactly '1', it's now a falsy check instead.

**Note that this file was further updated in March 2018 (the Blue Moon update), and that is not reflected here; that update added extra logic around applying air_dash_count, which I plan to have apply only for the final air dash rather than all extra air dashes on a player, though I'm looking for advice on how else this could behave.**

### Related Issue
N/A

### Implementation
Move iDashCount initialization with cvar check up before TF_COND_SODA_POPPER_HYPE check
Move Scout class check into ternary for iDashCount init
Move iNoAirDash check before iDashCount init and add it in the ternary
Change TF_COND_SODA_POPPER_HYPE condition to add to iDashCount instead of overriding all logic.

### Screenshots
N/A

### Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [?] This PR does not introduce any regressions.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
This should not affect stock server behavior, but I'd like some help testing it.

### Alternatives
N/A
