### PR TITLE
Don't callout giants when a sentry buster spawns

### DIFF
--- a/game/server/tf/player_vs_environment/tf_populator_spawners.cpp
+++ b/game/server/tf/player_vs_environment/tf_populator_spawners.cpp
@@ -1281,7 +1281,7 @@ bool CTFBotSpawner::Spawn( const Vector &rawHere, EntityHandleVector_t *result )
 
 		if ( TFGameRules()->IsMannVsMachineMode() )
 		{
-			if ( newBot->IsMiniBoss() )
+			if ( newBot->IsMiniBoss() && !newBot->HasMission( CTFBot::MISSION_DESTROY_SENTRIES )
 			{
 				TFGameRules()->HaveAllPlayersSpeakConceptIfAllowed( MP_CONCEPT_MVM_GIANT_CALLOUT, TF_TEAM_PVE_DEFENDERS );
 			}

--- a/game/server/tf/player_vs_environment/tf_populator_spawners.cpp
+++ b/game/server/tf/player_vs_environment/tf_populator_spawners.cpp
@@ -1281,7 +1281,7 @@ bool CTFBotSpawner::Spawn( const Vector &rawHere, EntityHandleVector_t *result )
 
 		if ( TFGameRules()->IsMannVsMachineMode() )
 		{
-			if ( newBot->IsMiniBoss() && !newBot->HasMission( CTFBot::MISSION_DESTROY_SENTRIES )
+			if ( newBot->IsMiniBoss() && !newBot->HasMission( CTFBot::MISSION_DESTROY_SENTRIES ) )
 			{
 				TFGameRules()->HaveAllPlayersSpeakConceptIfAllowed( MP_CONCEPT_MVM_GIANT_CALLOUT, TF_TEAM_PVE_DEFENDERS );
 			}


### PR DESCRIPTION
### Implementation
Normally everyone will call out a giant when a sentry buster spawns. This creates confusion as a sentry buster isn't a traditional giant. Now, it will make sure the miniboss is not a sentry buster before getting everyone to speak.

### Checklist
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Built, Tested | <!-- Built, Tested or N/A --> | Windows 10 |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
Probably none.

### Alternatives
Might be able to edit the SpeakConceptIfAllowed to prevent this too.
