### PR TITLE
Fix slope bug w/ surf maps

### DIFF
--- a/game/shared/gamemovement.cpp
+++ b/game/shared/gamemovement.cpp
@@ -4726,7 +4726,22 @@ void CGameMovement::PerformFlyCollisionResolution( trace_t &pm, Vector &move )
 
 	// stop if on ground
 	if (pm.plane.normal[2] > 0.7)
-	{		
+	{	
+		/*Prevent bug where player could stop dead while surfing upon colliding with a new slope
+		  This is a port of the groundfix sourcemod plugin by jayessZA & pancakelarry (steamid)
+		  https://github.com/laurirasanen/groundfix/blob/master/scripting/groundfix.sp#L246 */
+		if (pm.plane.normal[2] < 1.0 && DotProduct(mv->m_vecVelocity, pm.plane.normal) > 0.0) // not flat ground, is a slope (but not a surf ramp), moving up
+		{
+			Vector vPredictedVel;
+			ClipVelocity(mv->m_vecVelocity, pm.plane.normal, vPredictedVel, 1);
+
+			if (vPredictedVel[2] > 250.0)
+			{
+				DevMsg(1, "Prevented slope bug!\n");
+				return;
+			}
+		}
+
 		base.Init();
 		if (mv->m_vecVelocity[2] < GetCurrentGravity() * gpGlobals->frametime)
 		{

--- a/game/shared/gamemovement.cpp
+++ b/game/shared/gamemovement.cpp
@@ -4730,10 +4730,11 @@ void CGameMovement::PerformFlyCollisionResolution( trace_t &pm, Vector &move )
 		/*Prevent bug where player could stop dead while surfing upon colliding with a new slope
 		  This is a port of the groundfix sourcemod plugin by jayessZA & pancakelarry (steamid)
 		  https://github.com/laurirasanen/groundfix/blob/master/scripting/groundfix.sp#L246 */
-		if (pm.plane.normal[2] < 1.0 && DotProduct(mv->m_vecVelocity, pm.plane.normal) > 0.0) // not flat ground, is a slope (but not a surf ramp), moving up
+		if (pm.plane.normal[2] < 1.0 && DotProduct(mv->m_vecVelocity, pm.plane.normal) < 0.0) // not flat ground, is a slope (but not a surf ramp), moving up
 		{
-			Vector vPredictedVel;
-			ClipVelocity(mv->m_vecVelocity, pm.plane.normal, vPredictedVel, 1);
+			Vector vPredictedVel = mv->m_vecVelocity;
+			vPredictedVel[2] -= (0.5f * GetCurrentGravity() * gpGlobals->frametime);
+			ClipVelocity(vPredictedVel, pm.plane.normal, vPredictedVel, 1);
 
 			if (vPredictedVel[2] > 250.0)
 			{

--- a/game/shared/gamemovement.cpp
+++ b/game/shared/gamemovement.cpp
@@ -3591,23 +3591,6 @@ bool CGameMovement::CheckWater( void )
 void CGameMovement::SetGroundEntity( trace_t *pm )
 {
 	CBaseEntity *newGround = pm ? pm->m_pEnt : NULL;
-
-	/*Prevent bug where player could stop dead while surfing upon colliding with a new slope
-	This is a port of the groundfix sourcemod plugin by jayessZA & pancakelarry (steamid)
-	https://github.com/laurirasanen/groundfix/blob/master/scripting/groundfix.sp#L246 */
-	if (newGround && pm->plane.normal[2] > 0.7 && pm->plane.normal[2] < 1.0 && DotProduct(mv->m_vecVelocity, pm->plane.normal) < 0.0) // not flat ground, is a slope (but not a surf ramp), moving up
-	{
-		Vector vPredictedVel = mv->m_vecVelocity;
-		vPredictedVel[2] -= (0.5f * GetCurrentGravity() * gpGlobals->frametime);
-		ClipVelocity(vPredictedVel, pm->plane.normal, vPredictedVel, 1);
-
-		if (vPredictedVel[2] > 250.0)
-		{
-			DevMsg(1, "Prevented slope bug!\n");
-			return;
-		}
-	}
-
 	CBaseEntity *oldGround = player->GetGroundEntity();
 	Vector vecBaseVelocity = player->GetBaseVelocity();
 

--- a/game/shared/tf/tf_gamemovement.cpp
+++ b/game/shared/tf/tf_gamemovement.cpp
@@ -2426,6 +2426,18 @@ void CTFGameMovement::CategorizePosition( void )
 				mv->SetAbsOrigin( org );
 			}
 		}
+		if (trace.plane.normal.z < 1.0f && DotProduct(mv->m_vecVelocity, trace.plane.normal) < 0.0f) // not flat ground, is a slope (but not a surf ramp), moving up)
+		{
+			Vector vPredictedVel = mv->m_vecVelocity;
+			vPredictedVel[2] -= (0.5f * GetCurrentGravity() * gpGlobals->frametime);
+			ClipVelocity(vPredictedVel, trace.plane.normal, vPredictedVel, 1);
+
+			if (vPredictedVel[2] > 250.0)
+			{
+				DevMsg(1, "Prevented slope bug!\n");
+				trace.m_pEnt = NULL; // We're going too fast to actually land on the ground, so nullify the ground ent
+			}
+		}
 		SetGroundEntity( &trace );
 	}
 }


### PR DESCRIPTION
This pr fixes an issue with being stopped dead/momentum cancelled when surfing onto a new slope by adding an additional check to see if the player's predicted z velocity off the slope is still high enough to be considered above ground.

The code for this is ported from the `groundfix` sourcemod plugin by jayessZA and pancakelarry, which is used for jump.tf servers. More detailed explanation of the plugin & underlying bug can be found on [the discussion topic](https://jump.tf/forum/index.php/topic,2394.0.html) for it on jump.tf.

### Related issue
N/A

### Checklist
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Tested | Built | Windows 10 |
|   Linux | N/A | N/A | N/A |
|  Mac OS | N/A | N/A | N/A |

### Caveats
None found in testing

### Alternatives
N/A
