### PR TITLE
remove flamethrower lag compensation

### DIFF
--- a/game/shared/tf/tf_weapon_flamethrower.cpp
+++ b/game/shared/tf/tf_weapon_flamethrower.cpp
@@ -24,7 +24,6 @@
 	#include "explode.h"
 	#include "tf_player.h"
 	#include "tf_gamestats.h"
-	#include "ilagcompensationmanager.h"
 	#include "collisionutils.h"
 	#include "tf_team.h"
 	#include "tf_obj.h"
@@ -597,28 +596,11 @@ void CTFFlameThrower::PrimaryAttack()
 			RestartParticleEffect();
 		}
 	}
-#endif
 
-#if !defined (CLIENT_DLL)
-	// Let the player remember the usercmd he fired a weapon on. Assists in making decisions about lag compensation.
-	pOwner->NoteWeaponFired();
-
+	C_CTF_GameStats.Event_PlayerFiredWeapon( pOwner, IsCurrentAttackACrit() );
+#else
 	pOwner->SpeakWeaponFire();
 	CTF_GameStats.Event_PlayerFiredWeapon( pOwner, m_bCritFire );
-
-	// Move other players back to history positions based on local player's lag
-	lagcompensation->StartLagCompensation( pOwner, pOwner->GetCurrentCommand() );
-
-	// PASSTIME custom lag compensation for the ball; see also tf_fx_shared.cpp
-	// it would be better if all entities could opt-in to this, or a way for lagcompensation to handle non-players automatically
-	if ( g_pPasstimeLogic && g_pPasstimeLogic->GetBall() )
-	{
-		g_pPasstimeLogic->GetBall()->StartLagCompensation( pOwner, pOwner->GetCurrentCommand() );
-	}
-
-#endif
-#ifdef CLIENT_DLL
-	C_CTF_GameStats.Event_PlayerFiredWeapon( pOwner, IsCurrentAttackACrit() );
 #endif
 
 	float flFiringInterval = m_pWeaponInfo->GetWeaponData( m_iWeaponMode ).m_flTimeFireDelay;
@@ -713,17 +695,6 @@ void CTFFlameThrower::PrimaryAttack()
 
 	m_flNextPrimaryAttack = gpGlobals->curtime + flFiringInterval;
 	m_flTimeWeaponIdle = gpGlobals->curtime + flFiringInterval;
-
-#if !defined (CLIENT_DLL)
-	lagcompensation->FinishLagCompensation( pOwner );
-
-	// PASSTIME custom lag compensation for the ball; see also tf_fx_shared.cpp
-	// it would be better if all entities could opt-in to this, or a way for lagcompensation to handle non-players automatically
-	if ( g_pPasstimeLogic && g_pPasstimeLogic->GetBall() )
-	{
-		g_pPasstimeLogic->GetBall()->FinishLagCompensation( pOwner );
-	}
-#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/game/shared/tf/tf_weaponbase.cpp
+++ b/game/shared/tf/tf_weaponbase.cpp
@@ -31,6 +31,7 @@
 #include "tf_gamerules.h"
 #include "tf_gamestats.h"
 #include "ilagcompensationmanager.h"
+#include "tf_passtime_logic.h"
 #include "collisionutils.h"
 #include "tf_team.h"
 #include "tf_obj.h"
@@ -5464,6 +5465,13 @@ bool CTFWeaponBase::DeflectProjectiles()
 
 	lagcompensation->StartLagCompensation( pOwner, pOwner->GetCurrentCommand() );
 
+	// PASSTIME custom lag compensation for the ball; see also tf_fx_shared.cpp
+	// it would be better if all entities could opt-in to this, or a way for lagcompensation to handle non-players automatically
+	if ( g_pPasstimeLogic && g_pPasstimeLogic->GetBall() )
+	{
+		g_pPasstimeLogic->GetBall()->StartLagCompensation( pOwner, pOwner->GetCurrentCommand() );
+	}
+
 	Vector vecEye = pOwner->EyePosition();
 	Vector vecForward, vecRight, vecUp;
 	AngleVectors( pOwner->EyeAngles(), &vecForward, &vecRight, &vecUp );
@@ -5529,6 +5537,13 @@ bool CTFWeaponBase::DeflectProjectiles()
 	}
 
 	lagcompensation->FinishLagCompensation( pOwner );
+
+	// PASSTIME custom lag compensation for the ball; see also tf_fx_shared.cpp
+	// it would be better if all entities could opt-in to this, or a way for lagcompensation to handle non-players automatically
+	if ( g_pPasstimeLogic && g_pPasstimeLogic->GetBall() )
+	{
+		g_pPasstimeLogic->GetBall()->FinishLagCompensation( pOwner );
+	}
 
 	return true;
 }


### PR DESCRIPTION
for both tf2 and tc2, the server performs lag compensation for every time a flame particle is released

this doesn't actually help with lag at all, so it's an absolutely pointless waste of time for the server to do

this can be confirmed by using the sv_showlagcompensation cvar in a listen server

### Implementation
all lag compensation functions removed from the flamethrower's primaryattack function

### Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
||Client|Server|Version|
|-|:-:|:-:|-|
|Windows|no|no||
|Linux|yes|yes|5.8.0-1-amd64 #<!---->1 SMP Debian 5.8.7-1 (2020-09-05)|
|Mac OS|no|no||
