### PR TITLE
Increase max Ent/Edict limit

### DIFF
--- a/public/const.h
+++ b/public/const.h
@@ -62,7 +62,7 @@
 #define SP_MODEL_INDEX_BITS			13
 
 // How many bits to use to encode an edict.
-#define	MAX_EDICT_BITS				11			// # of bits needed to represent max edicts
+#define	MAX_EDICT_BITS				14			// # of bits needed to represent max edicts
 // Max # of edicts in a level
 #define	MAX_EDICTS					(1<<MAX_EDICT_BITS)
 


### PR DESCRIPTION
### Related Issue
#134 

### Implementation
Bumped up the bitshift from 1<<11 (2048 Ents) to 1<<14 (16384 Ents). I'm not sure if this will effect packing the entity data or not, since that is also set at 16384. If it does, we can always go down to 1<<13 (8192).
So far everything works fine on my [test map](https://github.com/mastercomfig/team-comtress-2/files/5322530/entity.zip) (tested listen and dedicated) which spawns approximately 1200 barrels/s.

### Screenshots
https://www.youtube.com/watch?v=NeFc8dnNemw

### Checklist
- [x] This PR targets the `master` branch.
- [x] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [ ] This PR does not introduce any regressions.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to answer "yes" to all of these to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Built, Tested | Built, Tested | Windows 10    |
|   Linux | N/A | N/A | N/A |
|  Mac OS | N/A | N/A | N/A      |

### Caveats
None so far from my tests.