### PR TITLE
Fix hardcoded space on localized quality names

### DIFF
--- a/game/shared/econ/econ_item_description.cpp
+++ b/game/shared/econ/econ_item_description.cpp
@@ -891,7 +891,7 @@ static void GenerateLocalizedFullItemName
 				if ( pQualityLocalizedString )
 				{
 					loc_scpy_safe( szQuality, pQualityLocalizedString );
-					loc_scat_safe( szQuality, LOCCHAR(" ") );
+					loc_scat_safe( szQuality, LOCCHAR("") );
 				}
 			}
 		}
@@ -3579,7 +3579,7 @@ void CEconItemDescription::Generate_DirectX8Warning( const CLocalizationProvider
 #ifdef CLIENT_DLL
 	static ConVarRef mat_dxlevel( "mat_dxlevel" );
 	const CEconItemDefinition *pEconItemDefinition = pEconItem->GetItemDefinition();
-	// If less than 90, we’re in DX8 mode. 
+	// If less than 90, weÂ’re in DX8 mode. 
 	// Display warning if you are looking at a painthit item or case
 	if ( mat_dxlevel.GetInt() < 90 && pEconItemDefinition && ( pEconItemDefinition->GetItemCollectionDefinition() || pEconItemDefinition->GetCollectionReference() ) )
 	{


### PR DESCRIPTION
### Related Issue
None

### Implementation
Since before the Jungle Inferno update, there was a visual bug that affected localized item quality names. A hardcoded space was introduced and being part of the STS team, I talked to my colleagues which confirmed to me that this bug existed since 2015 or so. You can see here an screenshot of how it looks like:

![image](https://user-images.githubusercontent.com/1251067/95074826-7728d280-070f-11eb-9127-616fb6545783.png)

As you can see, there is an extra space in the quality name of the item, and it's not a problem specific to this language as it was noticed in other languages too.

This PR fixes this issue.

### Screenshots
![Screenshot from 2020-10-05 12-33-50](https://user-images.githubusercontent.com/1251067/95074949-a50e1700-070f-11eb-9d8a-e5abfe0fd873.png)


### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | Built and tested| N/A | `5.8.12-arch1-1 #1 SMP PREEMPT Sat, 26 Sep 2020 21:42:58 +0000` |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
None.

### Alternatives
None.
