### PR TITLE
Add building check

### DIFF
--- a/game/client/tf/c_obj_teleporter.cpp
+++ b/game/client/tf/c_obj_teleporter.cpp
@@ -428,7 +428,19 @@ bool C_ObjectTeleporter::IsPlacementPosValid( void )
 	trace_t tr;
 	UTIL_TraceHull( vecTestPos, vecTestPos, VEC_HULL_MIN, VEC_HULL_MAX, MASK_SOLID | CONTENTS_PLAYERCLIP, this, COLLISION_GROUP_PLAYER_MOVEMENT, &tr );
 
-	return ( tr.fraction >= 1.0 );
+	if ( tr.fraction < 1.0 )
+		return false;
+
+	// make sure no buildings are above us
+	UTIL_TraceHull( vecTestPos, vecTestPos, VEC_HULL_MIN, VEC_HULL_MAX, MASK_SOLID | CONTENTS_PLAYERCLIP, this, COLLISION_GROUP_NONE, &tr );
+
+	if ( tr.m_pEnt )
+    {
+        if ( FClassnameIs( tr.m_pEnt, "obj_dispenser" ) || FClassnameIs( tr.m_pEnt, "obj_sentrygun" ) || FClassnameIs( tr.m_pEnt, "obj_teleporter" ) )
+            return false;
+    }
+
+	return true;
 }
 //-----------------------------------------------------------------------------
 // 

--- a/game/server/tf/tf_obj_teleporter.cpp
+++ b/game/server/tf/tf_obj_teleporter.cpp
@@ -450,7 +450,19 @@ bool CObjectTeleporter::IsPlacementPosValid( void )
 	trace_t tr;
 	UTIL_TraceHull( vecTestPos, vecTestPos, VEC_HULL_MIN, VEC_HULL_MAX, MASK_SOLID | CONTENTS_PLAYERCLIP, this, COLLISION_GROUP_PLAYER_MOVEMENT, &tr );
 
-	return ( tr.fraction >= 1.0 );
+	if ( tr.fraction < 1.0 )
+		return false;
+
+	// make sure no buildings are above us
+	UTIL_TraceHull( vecTestPos, vecTestPos, VEC_HULL_MIN, VEC_HULL_MAX, MASK_SOLID | CONTENTS_PLAYERCLIP, this, COLLISION_GROUP_NONE, &tr );
+
+	if ( tr.m_pEnt )
+    {
+        if ( FClassnameIs( tr.m_pEnt, "obj_dispenser" ) || FClassnameIs( tr.m_pEnt, "obj_sentrygun" ) || FClassnameIs( tr.m_pEnt, "obj_teleporter" ) )
+            return false;
+    }
+
+	return true;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
### Related Issue
#236
#237

### Implementation
Added a check to see if we have a building above us when trying to build a teleporter.

### Checklist
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).

- [x] This PR targets the `master` branch.
- [x] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Built, Tested | Built, Tested | Windows 10    |
|   Linux | N/A | N/A | N/A |
|  Mac OS | N/A | N/A | N/A      |