### PR TITLE
Remove teleporter sound on pickup

### DIFF
--- a/game/client/tf/c_obj_teleporter.cpp
+++ b/game/client/tf/c_obj_teleporter.cpp
@@ -457,5 +457,10 @@ void C_ObjectTeleporter::OnGoInactive( void )
 	StopBuildingEffects();
 	StopChargedEffects();
 
+	if ( m_pSpinSound )
+	{
+		CSoundEnvelopeController::GetController().SoundDestroy( m_pSpinSound );
+	}
+
 	BaseClass::OnGoInactive();
 }

--- a/game/client/tf/c_obj_teleporter.cpp
+++ b/game/client/tf/c_obj_teleporter.cpp
@@ -460,6 +460,7 @@ void C_ObjectTeleporter::OnGoInactive( void )
 	if ( m_pSpinSound )
 	{
 		CSoundEnvelopeController::GetController().SoundDestroy( m_pSpinSound );
+		m_pSpinSound = NULL;
 	}
 
 	BaseClass::OnGoInactive();


### PR DESCRIPTION
### Related Issue
#253

### Implementation
Kill sound when picking up teleporter.

### Checklist
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).

- [x] This PR targets the `master` branch.
- [x] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Built, Tested | Built, Tested | Windows 10    |
|   Linux | N/A | N/A | N/A |
|  Mac OS | N/A | N/A | N/A      |