### PR TITLE
Allow item whitelist in non-tournament mode

### DIFF
--- a/game/server/tf/tf_player.cpp
+++ b/game/server/tf/tf_player.cpp
@@ -4709,7 +4709,7 @@ CEconItemView *CTFPlayer::GetLoadoutItem( int iClass, int iSlot, bool bReportWhi
 
 	// Check to see if this item passes the tournament rules (in whitelist/or normal quality).
 	// If it doesn't, we fall back to the base item for the loadout slot.
-	if ( (pItem && pItem->IsValid()) && (pItem->GetItemQuality() != AE_NORMAL) && !pItem->GetStaticData()->IsAllowedInMatch() && TFGameRules()->IsInTournamentMode() )
+	if ( (pItem && pItem->IsValid()) && (pItem->GetItemQuality() != AE_NORMAL) && !pItem->GetStaticData()->IsAllowedInMatch() )
 	{
 		if ( bReportWhitelistFails )
 		{

--- a/game/shared/econ/econ_item_system.cpp
+++ b/game/shared/econ/econ_item_system.cpp
@@ -118,6 +118,7 @@ extern ConVar mp_tournament;
 
 #ifdef GAME_DLL
 ConVar mp_tournament_whitelist( "mp_tournament_whitelist", "item_whitelist.txt", FCVAR_NONE, "Specifies the item whitelist file to use." );
+ConVar mp_tournament_allow_whitelist_in_non_tournament( "mp_tournament_allow_whitelist_in_non_tournament", "0", FCVAR_REPLICATED | FCVAR_NOTIFY, "Allows the tournament whitelist to be loaded in non-tournament games." );
 #endif
 
 //-----------------------------------------------------------------------------
@@ -132,7 +133,7 @@ void CEconItemSystem::ReloadWhitelist( void )
 	KeyValues *pWhitelistKV = new KeyValues( "item_whitelist" );
 
 #ifdef GAME_DLL
-	if ( mp_tournament.GetBool() && mp_tournament_whitelist.GetString() )
+	if ( (mp_tournament.GetBool() && mp_tournament_whitelist.GetString()) || (mp_tournament_allow_whitelist_in_non_tournament.GetBool() && mp_tournament_whitelist.GetString()) )
 	{
 		const char *pszWhitelistFile = mp_tournament_whitelist.GetString();
 		if ( pWhitelistKV->LoadFromFile( filesystem, pszWhitelistFile ) )


### PR DESCRIPTION
### Related Issue
#137

### Implementation
Removed a tournament check in tf_player.
Added a new Cvar **mp_tournament_allow_whitelist_in_non_tournament**

### Checklist
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR targets the `master` branch.
- [x] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Built, Tested | Built, Tested | Windows 10    |
|   Linux | N/A | N/A | N/A |
|  Mac OS | N/A | N/A | N/A |

### Caveats
None so far?