### PR TITLE
Fix secondary fire weirdness

### DIFF
--- a/game/shared/basecombatweapon_shared.cpp
+++ b/game/shared/basecombatweapon_shared.cpp
@@ -1692,8 +1692,6 @@ void CBaseCombatWeapon::ItemPostFrame( void )
 		CheckReload();
 	}
 
-	bool bFired = false;
-
 	// Secondary attack has priority
 	if ((pOwner->m_nButtons & IN_ATTACK2) && CanPerformSecondaryAttack() )
 	{
@@ -1714,17 +1712,6 @@ void CBaseCombatWeapon::ItemPostFrame( void )
 		}
 		else
 		{
-			// FIXME: This isn't necessarily true if the weapon doesn't have a secondary fire!
-			// For instance, the crossbow doesn't have a 'real' secondary fire, but it still 
-			// stops the crossbow from firing on the 360 if the player chooses to hold down their
-			// zoom button. (sjb) Orange Box 7/25/2007
-#if !defined(CLIENT_DLL)
-			if( !IsX360() || !ClassMatches("weapon_crossbow") )
-#endif
-			{
-				bFired = ShouldBlockPrimaryFire();
-			}
-
 			SecondaryAttack();
 
 			// Secondary ammo doesn't have a reload animation
@@ -1740,7 +1727,7 @@ void CBaseCombatWeapon::ItemPostFrame( void )
 		}
 	}
 	
-	if ( !bFired && (pOwner->m_nButtons & IN_ATTACK) && (m_flNextPrimaryAttack <= gpGlobals->curtime))
+	if ( (pOwner->m_nButtons & IN_ATTACK) && (m_flNextPrimaryAttack <= gpGlobals->curtime) )
 	{
 		// Clip empty? Or out of ammo on a no-clip weapon?
 		if ( !IsMeleeWeapon() &&  
@@ -1795,7 +1782,7 @@ void CBaseCombatWeapon::ItemPostFrame( void )
 	// -----------------------
 	//  No buttons down
 	// -----------------------
-	if (!((pOwner->m_nButtons & IN_ATTACK) || (pOwner->m_nButtons & IN_ATTACK2) || (CanReload() && pOwner->m_nButtons & IN_RELOAD)))
+	if (!((pOwner->m_nButtons & IN_ATTACK) || (CanReload() && pOwner->m_nButtons & IN_RELOAD)))
 	{
 		// no fire buttons down or reloading
 		if ( !ReloadOrSwitchWeapons() && ( m_bInReload == false ) )

--- a/game/shared/tf/tf_weaponbase.cpp
+++ b/game/shared/tf/tf_weaponbase.cpp
@@ -2249,7 +2249,7 @@ void CTFWeaponBase::ItemPostFrame( void )
 	bool bNeedsReload = NeedsReloadForAmmo1( GetMaxClip1() ) || ( IsEnergyWeapon() && !Energy_FullyCharged() );
 
 	// If we're not shooting, and we want to autoreload, press our reload key
-	if ( !AutoFiresFullClip() && pOwner->ShouldAutoReload() && UsesClipsForAmmo1() && !(pOwner->m_nButtons & (IN_ATTACK|IN_ATTACK2)) && bNeedsReload )
+	if ( !AutoFiresFullClip() && pOwner->ShouldAutoReload() && UsesClipsForAmmo1() && !(pOwner->m_nButtons & IN_ATTACK) && bNeedsReload )
 	{
 		pOwner->m_nButtons |= IN_RELOAD;
 	}


### PR DESCRIPTION
1. Can now use primary fire while holding secondary fire on soldier.
2. Fixed auto-reload not working while holding secondary fire.
3. Fixed the idle animation when secondary fire is being held.
4. Fixed not being able to detonate stickies when swapping weapons.

### Related Issue
#278

### Implementation
Removed some M2 checks.
Removed a primary fire check which only happened on Soldier - it shouldn't be needed.

### Checklist
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR targets the `master` branch.
- [x] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Built, Tested | Built, Tested | Windows 10    |
|   Linux | N/A | N/A | N/A |
|  Mac OS | N/A | N/A | N/A |

### Caveats
I have tested this quite a bit, but if anything breaks, it will be from me removing one of the primary fire block for solder's rocket launcher. I checked all the logic in all rocket launchers, and they all have checks, so it _hopefully_ shouldn't be a problem.