### PR TITLE
Add check to Cow Mangler before firing

### DIFF
--- a/game/shared/tf/tf_weapon_particle_cannon.cpp
+++ b/game/shared/tf/tf_weapon_particle_cannon.cpp
@@ -184,6 +184,11 @@ void CTFParticleCannon::PrimaryAttack( void )
 //-----------------------------------------------------------------------------
 void CTFParticleCannon::SecondaryAttack( void )
 {
+	CTFPlayer *pPlayer = ToTFPlayer( GetPlayerOwner() );
+
+	if ( (pPlayer->m_nButtons & IN_ATTACK) )
+		return;
+
 	// Check for ammunition.
 	if ( !Energy_FullyCharged() )
 	{
@@ -212,7 +217,6 @@ void CTFParticleCannon::SecondaryAttack( void )
 	// save that we had the attack button down
 	m_flChargeBeginTime = gpGlobals->curtime;
 
-	CTFPlayer *pPlayer = ToTFPlayer( GetPlayerOwner() );
 	if ( pPlayer )
 	{
 		SendWeaponAnim( ACT_PRIMARY_VM_PRIMARYATTACK_3 );


### PR DESCRIPTION
### Related Issue
#434

### Implementation
Adds a key check before trying to fire.

### Checklist
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR targets the `master` branch.
- [x] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Built, Tested | Built, Tested | Windows 10    |
|   Linux | N/A | N/A | N/A |
|  Mac OS | N/A | N/A | N/A |