### PR TITLE
Disallow holding rockets with looping taunts

### DIFF
--- a/game/shared/tf/tf_player_shared.cpp
+++ b/game/shared/tf/tf_player_shared.cpp
@@ -708,6 +708,13 @@ bool CTFPlayer::IsAllowedToTaunt( void )
 	if ( m_Shared.InCond( TF_COND_GRAPPLED_TO_PLAYER ) )
 		return false;
 
+	if ( IsPlayerClass( TF_CLASS_SOLDIER ) )
+	{
+		// Stop from taunting if we have any rockets overloaded in the Beggers Bazooka
+		if ( pActiveWeapon && pActiveWeapon->CanOverload() && pActiveWeapon->Clip1() > 0 )
+			return false;
+	}
+
 	if ( IsPlayerClass( TF_CLASS_SCOUT ) )
 	{
 		if ( pActiveWeapon && pActiveWeapon->GetWeaponID() == TF_WEAPON_LUNCHBOX )

--- a/game/shared/tf/tf_player_shared.cpp
+++ b/game/shared/tf/tf_player_shared.cpp
@@ -710,7 +710,7 @@ bool CTFPlayer::IsAllowedToTaunt( void )
 
 	if ( IsPlayerClass( TF_CLASS_SOLDIER ) )
 	{
-		// Stop from taunting if we have any rockets overloaded in the Begger's Bazooka
+		// Stop from taunting if we have any rockets overloaded in the Beggar's Bazooka
 		if ( pActiveWeapon && pActiveWeapon->CanOverload() && pActiveWeapon->Clip1() > 0 )
 			return false;
 	}

--- a/game/shared/tf/tf_player_shared.cpp
+++ b/game/shared/tf/tf_player_shared.cpp
@@ -710,7 +710,7 @@ bool CTFPlayer::IsAllowedToTaunt( void )
 
 	if ( IsPlayerClass( TF_CLASS_SOLDIER ) )
 	{
-		// Stop from taunting if we have any rockets overloaded in the Beggers Bazooka
+		// Stop from taunting if we have any rockets overloaded in the Begger's Bazooka
 		if ( pActiveWeapon && pActiveWeapon->CanOverload() && pActiveWeapon->Clip1() > 0 )
 			return false;
 	}

--- a/game/shared/tf/tf_weapon_rocketlauncher.cpp
+++ b/game/shared/tf/tf_weapon_rocketlauncher.cpp
@@ -399,7 +399,7 @@ bool CTFRocketLauncher::CanReload( void )
 {
 	CTFPlayer *pPlayer = GetTFPlayerOwner();
 
-	// Need this here since the beggers Bazooka has a delay before loading a rocket
+	// Need this here since the Beggar's Bazooka has a delay before loading a rocket
 	// If we taunt just as we are about to load the rocket, we can store the rocket
 	if ( CanOverload() && pPlayer->m_Shared.InCond( TF_COND_TAUNTING ) )
 		return false;

--- a/game/shared/tf/tf_weapon_rocketlauncher.cpp
+++ b/game/shared/tf/tf_weapon_rocketlauncher.cpp
@@ -392,6 +392,21 @@ bool CTFRocketLauncher::DefaultReload( int iClipSize1, int iClipSize2, int iActi
 	return BaseClass::DefaultReload( iClipSize1, iClipSize2, iActivity );
 }
 
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+bool CTFRocketLauncher::CanReload( void )
+{
+	CTFPlayer *pPlayer = GetTFPlayerOwner();
+
+	// Need this here since the beggers Bazooka has a delay before loading a rocket
+	// If we taunt just as we are about to load the rocket, we can store the rocket
+	if ( CanOverload() && pPlayer->m_Shared.InCond( TF_COND_TAUNTING ) )
+		return false;
+
+	return true;
+}
+
 #ifdef CLIENT_DLL
 //-----------------------------------------------------------------------------
 // Purpose: 

--- a/game/shared/tf/tf_weapon_rocketlauncher.h
+++ b/game/shared/tf/tf_weapon_rocketlauncher.h
@@ -67,6 +67,8 @@ public:
 
 	virtual bool	ShouldBlockPrimaryFire() OVERRIDE;
 
+	virtual bool	CanReload( void );
+
 #ifdef CLIENT_DLL
 	virtual void CreateMuzzleFlashEffects( C_BaseEntity *pAttachEnt, int nIndex );
 #endif


### PR DESCRIPTION
Disallow holding overloaded Beggar's Bazooka rockets using any looping taunt.

### Related Issue
https://github.com/ValveSoftware/Source-1-Games/issues/2703

### Implementation
Added a check for overloading in IsAllowedToTaunt.
Added CTFRocketLauncher::CanReload. If we don't have this check, we could just click while in the taunt and load and hold a single rocket.

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR targets the `master` branch.
- [x] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Built, Tested | Built, Tested | Windows 10    |
|   Linux | N/A | N/A | N/A |
|  Mac OS | N/A | N/A | N/A |