### PR TITLE
Make bots fire Wrap Assassin balls, similar to how they use the Sandman

### DIFF
--- a/game/server/tf/bot/tf_bot.cpp
+++ b/game/server/tf/bot/tf_bot.cpp
@@ -4250,7 +4250,7 @@ Action< CTFBot > *CTFBot::OpportunisticallyUseWeaponAbilities( void )
 				}
 			}
 		}
-		else if ( weapon->GetWeaponID() == TF_WEAPON_BAT_WOOD )
+		else if ( weapon->GetWeaponID() == TF_WEAPON_BAT_WOOD || TF_WEAPON_BAT_GIFTWRAP )
 		{
 			// sandman
 			if ( GetAmmoCount( TF_AMMO_GRENADES1 ) > 0 )


### PR DESCRIPTION
### Implementation
Just adding an "or" for TF_WEAPON_BAT_WOOD to add TF_WEAPON_BAT_GIFTWRAP

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [x] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Built, Tested | Built | Windows 10 |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
None?

### Alternatives
Probably could force CTFBat_Giftwrap::GetWeaponID to return TF_WEAPON_BAT_WOOD if called from CTFBot::OpportunisticallyUseWeaponAbilities, this seems like a more straightforward solution though.