### PR TITLE
Make hand/head/torso scaling instantaneous in MvM mode

### DIFF
--- a/game/server/tf/tf_player.cpp
+++ b/game/server/tf/tf_player.cpp
@@ -21566,6 +21566,10 @@ float CTFPlayer::GetDesiredHeadScale() const
 //-----------------------------------------------------------------------------
 float CTFPlayer::GetHeadScaleSpeed() const
 {
+	if ( TFGameRules()->IsMannVsMachineMode() ) 
+	{
+		return FLT_MAX;
+	}
 	// change size now
 	if (
 		m_Shared.InCond( TF_COND_HALLOWEEN_BOMB_HEAD ) ||
@@ -21595,6 +21599,10 @@ float CTFPlayer::GetDesiredTorsoScale() const
 //-----------------------------------------------------------------------------
 float CTFPlayer::GetTorsoScaleSpeed() const
 {
+	if ( TFGameRules()->IsMannVsMachineMode() ) 
+	{
+		return FLT_MAX;
+	}
 	return gpGlobals->frametime;
 }
 
@@ -21613,6 +21621,10 @@ float CTFPlayer::GetDesiredHandScale() const
 //-----------------------------------------------------------------------------
 float CTFPlayer::GetHandScaleSpeed() const
 {
+	if ( TFGameRules()->IsMannVsMachineMode() ) 
+	{
+		return FLT_MAX;
+	}
 	if ( m_Shared.InCond( TF_COND_MELEE_ONLY ) )
 	{
 		return GetDesiredHandScale();


### PR DESCRIPTION
### Related Issue
MvM giant's can sometimes be seen scaling upwards when spawning.

### Implementation
Make CTFPlayer::GetHandScaleSpeed, CTFPlayer::GetHeadScaleSpeed and CTFPlayer::GetTorsoScaleSpeed all return FLT_MAX in MvM mode.

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Built, Tested | Built | Windows 10 |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
Might mess with server plugins that change head, torso or hand sizes in MvM mode?

### Alternatives
Could probably just force changing the size without calling scaling speed in MvM.
