### PR TITLE
Allow disposable sentries to be used outside MVM

### DIFF
--- a/game/client/tf/tf_hud_building_status.cpp
+++ b/game/client/tf/tf_hud_building_status.cpp
@@ -1317,14 +1317,11 @@ void CHudBuildingStatusContainer_Engineer::OnTick()
 	{
 		bool bDisposableSentriesVisible = false;
 
-		if ( TFGameRules() && TFGameRules()->GameModeUsesUpgrades() )
+		int nDisposableSentries = 0;
+		CALL_ATTRIB_HOOK_INT_ON_OTHER( pLocalPlayer, nDisposableSentries, engy_disposable_sentries );
+		if ( nDisposableSentries )
 		{
-			int nDisposableSentries = 0;
-			CALL_ATTRIB_HOOK_INT_ON_OTHER( pLocalPlayer, nDisposableSentries, engy_disposable_sentries );
-			if ( nDisposableSentries )
-			{
-				bDisposableSentriesVisible = true;
-			}
+			bDisposableSentriesVisible = true;
 		}
 
 #ifdef STAGING_ONLY	

--- a/game/server/tf/tf_obj.cpp
+++ b/game/server/tf/tf_obj.cpp
@@ -1444,17 +1444,16 @@ bool CBaseObject::ShouldBeMiniBuilding( CTFPlayer* pPlayer )
 	if ( !pPlayer )
 		return false;
 
-	CTFWrench* pWrench = dynamic_cast<CTFWrench*>( pPlayer->Weapon_OwnsThisID( TF_WEAPON_WRENCH ) );
-	if ( !pWrench )
-		return false;
-
-	if ( TFGameRules()->GameModeUsesUpgrades() )
+	int nDisposableSentries = 0;
+	CALL_ATTRIB_HOOK_INT_ON_OTHER( pPlayer, nDisposableSentries, engy_disposable_sentry );
+	if ( nDisposableSentries > 0 )
 	{
 		if ( pPlayer->GetNumObjects( OBJ_SENTRYGUN ) && pPlayer->CanBuild( OBJ_SENTRYGUN ) == CB_CAN_BUILD && !IsCarried() )
 			return true;	
 	}
 
-	if ( !pWrench->IsPDQ() )
+	CTFWrench* pWrench = dynamic_cast<CTFWrench*>( pPlayer->Weapon_OwnsThisID( TF_WEAPON_WRENCH ) );
+	if ( !pWrench || !pWrench->IsPDQ() )
 		return false;
 
 	return true;

--- a/game/shared/tf/tf_player_shared.cpp
+++ b/game/shared/tf/tf_player_shared.cpp
@@ -10820,7 +10820,7 @@ int CTFPlayer::CanBuild( int iObjectType, int iObjectMode )
 	}
 
 	// Special handling of "disposable" sentries
-	if ( TFGameRules()->GameModeUsesUpgrades() && iObjectType == OBJ_SENTRYGUN )
+	if ( iObjectType == OBJ_SENTRYGUN )
 	{
 		// If we have our main sentry, see if we're allowed to build disposables
 		if ( GetNumObjects( iObjectType, iObjectMode ) )


### PR DESCRIPTION
(if the relevant attribute is present)

This also corrects an issue where a disposable sentry would not be a minisentry if the player's melee weapon was not a wrench/gunslinger (normally, all disposable sentries are also minisentries).

### Related Issue
<!-- Number of the issue where this topic was mentioned -->
N/A

### Implementation
<!-- A clear and concise description of what the changes are -->
Removes the GameModeUsesUpgrades checks from places that involve Disposable sentry code and instead strictly relies on the presence of the engy_disposable_sentry attribute.

### Screenshots
<!-- Add screenshots if applicable -->

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [ ] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [ ] This PR does not introduce any regressions.
- [ ] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
I need some help testing this if possible.
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
<!-- Any caveats and side effects of this PR -->

### Alternatives
<!-- Alternatives that were considered -->
