### PR TITLE
Allow set_scattergun_has_knockback attribute to take on values greater than 1

### DIFF
--- a/game/server/tf/tf_player.cpp
+++ b/game/server/tf/tf_player.cpp
@@ -878,7 +878,7 @@ CTFPlayer::CTFPlayer()
 	m_flNextChangeClassTime = 0.0f;
 	m_flNextChangeTeamTime = 0.0f;
 
-	m_bScattergunJump = false;
+	m_iScattergunJump = 0;
 	m_iOldStunFlags = 0;
 	m_iLastWeaponSlot = 1;
 	m_iNumberofDominations = 0;
@@ -3641,7 +3641,7 @@ void CTFPlayer::Spawn()
 
 	m_Shared.SetFeignDeathReady( false );
 
-	m_bScattergunJump = false;
+	m_iScattergunJump = 0;
 	m_iOldStunFlags = 0;
 
 	m_flAccumulatedHealthRegen = 0;

--- a/game/server/tf/tf_player.h
+++ b/game/server/tf/tf_player.h
@@ -811,7 +811,7 @@ public:
 
 	bool				m_bSuicideExplode;
 
-	bool				m_bScattergunJump;
+	int					m_iScattergunJump;
 	int					m_iOldStunFlags;
 
 	bool				m_bFlipViewModels;

--- a/game/shared/tf/tf_gamemovement.cpp
+++ b/game/shared/tf/tf_gamemovement.cpp
@@ -2928,7 +2928,7 @@ void CTFGameMovement::SetGroundEntity( trace_t *pm )
 			m_pTFPlayer->SpeakConceptIfAllowed( MP_CONCEPT_DOUBLE_JUMP, "started_jumping:0" );
 		}
 		m_pTFPlayer->m_Shared.SetWeaponKnockbackID( -1 );
-		m_pTFPlayer->m_bScattergunJump = false;
+		m_pTFPlayer->m_iScattergunJump = 0;
 #endif // GAME_DLL
 		m_pTFPlayer->m_Shared.SetAirDash( 0 );
 		m_pTFPlayer->m_Shared.SetAirDucked( 0 );

--- a/game/shared/tf/tf_quest_restriction.cpp
+++ b/game/shared/tf/tf_quest_restriction.cpp
@@ -1063,7 +1063,7 @@ protected:
 
 		int nNumJumps = pNonConstPlayer->GetGroundEntity() == NULL ? 1 : 0;
 		nNumJumps += pPlayer->m_Shared.GetAirDash();
-		nNumJumps += pPlayer->m_bScattergunJump;
+		nNumJumps += pPlayer->m_iScattergunJump;
 
 		if ( m_eJumpingState == JUMPING_STATE_IS_NOT_JUMPING )
 		{

--- a/game/shared/tf/tf_weapon_shotgun.cpp
+++ b/game/shared/tf/tf_weapon_shotgun.cpp
@@ -318,7 +318,10 @@ extern float AirBurstDamageForce( const Vector &size, float damage, float scale 
 void CTFScatterGun::FireBullet( CTFPlayer *pPlayer )
 {
 #ifndef CLIENT_DLL
-	if ( HasKnockback() )
+	// see CTFScatterGun::HasKnockback
+	int iKnockbackCount = 0;
+	CALL_ATTRIB_HOOK_INT( iKnockbackCount, set_scattergun_has_knockback );
+	if ( iKnockbackCount > 0 )
 	{
 		// Perform some knock back.
 		CTFPlayer *pOwner = ToTFPlayer( GetPlayerOwner() );
@@ -330,9 +333,9 @@ void CTFScatterGun::FireBullet( CTFPlayer *pPlayer )
 			return;
 
 		// Knock the firer back!
-		if ( !(pOwner->GetFlags() & FL_ONGROUND) && !pPlayer->m_bScattergunJump )
+		if ( !(pOwner->GetFlags() & FL_ONGROUND) && pPlayer->m_iScattergunJump < iKnockbackCount )
 		{
-			pPlayer->m_bScattergunJump = true;
+			pPlayer->m_iScattergunJump += 1;
 
 			pOwner->m_Shared.StunPlayer( 0.3f, 1.f, TF_STUN_MOVEMENT | TF_STUN_MOVEMENT_FORWARD_ONLY );
 
@@ -436,9 +439,9 @@ void CTFScatterGun::FinishReload( void )
 //-----------------------------------------------------------------------------
 bool CTFScatterGun::HasKnockback( void )
 {
-	int iWeaponMod = 0;
-	CALL_ATTRIB_HOOK_INT( iWeaponMod, set_scattergun_has_knockback );
-	if ( iWeaponMod == 1 )
+	int iKnockbackCount = 0;
+	CALL_ATTRIB_HOOK_INT( iKnockbackCount, set_scattergun_has_knockback );
+	if ( iKnockbackCount > 0 )
 		return true;
 	else
 		return false;


### PR DESCRIPTION
This increases the number of times self-knockback may be applied via the attribute.
This also changes m_bScattergunJump to m_iScattergunJump and updates any relevant code accordingly.

### Related Issue
<!-- Number of the issue where this topic was mentioned -->
N/A

### Implementation
<!-- A clear and concise description of what the changes are -->
Changes CTFPlayer's m_bScattergunJump to int m_iScattergunJump.
Changes CTFScattergun's HasKnockback method to return true for values > 0 rather than only value 1.
Changes CTFScatterGun's FireBullet knockback logic to compare the value of m_iScattergunJump to the attribute value in order to determine whether to apply self-knockback.

### Screenshots
<!-- Add screenshots if applicable -->

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [ ] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [ ] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
I need some help testing this as my current setup can't... do anything.
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
<!-- Any caveats and side effects of this PR -->
CTFPlayer offsets may change since the bool was widened to an int.

### Alternatives
<!-- Alternatives that were considered -->
