### PR TITLE
[MvM] Removal of popup checker in Upgrade Station UI

### DIFF
--- a/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
+++ b/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
@@ -475,7 +475,7 @@ bool CHudUpgradePanel::ShouldDraw( void )
 
 		bool bInZone = m_hPlayer->m_Shared.IsInUpgradeZone();
 
-		// check for other popups
+		//// check for other popups
 		//if ( bInZone && !CHudElement::ShouldDraw() ) 
 		//{
 		//	CTFStatPanel *pStatPanel = GetStatPanel();

--- a/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
+++ b/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
@@ -476,15 +476,15 @@ bool CHudUpgradePanel::ShouldDraw( void )
 		bool bInZone = m_hPlayer->m_Shared.IsInUpgradeZone();
 
 		// check for other popups
-		if ( bInZone && !CHudElement::ShouldDraw() ) 
-		{
-			CTFStatPanel *pStatPanel = GetStatPanel();
-			if ( pStatPanel->IsVisible() )
-			{
-				pStatPanel->Hide();
-				return false;
-			}
-		}
+		//if ( bInZone && !CHudElement::ShouldDraw() ) 
+		//{
+		//	CTFStatPanel *pStatPanel = GetStatPanel();
+		//	if ( pStatPanel->IsVisible() )
+		//	{
+		//		pStatPanel->Hide();
+		//		return false;
+		//	}
+		//}
 
 		if ( m_bWasInZone != bInZone )
 		{


### PR DESCRIPTION
### Related Issue
#342

### Implementation
Removes popup check from the Upgrade Station UI, stopping it from being hidden from the client on certain prompts 

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [ ] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] This PR targets the `master` branch.
- [x] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [ ] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Built and Tested | Tested on Listen | Windows 10 Home    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |
