### PR TITLE
Fix MVM upgrade shop allowing movement

### DIFF
--- a/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
+++ b/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
@@ -37,6 +37,9 @@
 
 #define UPGRADE_PANEL_LEVEL_LABEL_COUNT 10
 
+#ifdef CLIENT_DLL
+ConVar tf_mvm_move_in_shop("tf_mvm_move_in_shop", "0", FCVAR_ARCHIVE, "Allow keyboard input while in the upgrade shop.");
+#endif
 
 extern CAchievementMgr g_AchievementMgrTF;
 
@@ -461,6 +464,7 @@ bool CHudUpgradePanel::ShouldDraw( void )
 	if ( !m_bInspectMode )
 	{
 		m_hPlayer = C_TFPlayer::GetLocalTFPlayer();
+		SetKeyBoardInputEnabled(false);
 	}
 
 	// Local mode
@@ -474,9 +478,9 @@ bool CHudUpgradePanel::ShouldDraw( void )
 		}
 
 		bool bInZone = m_hPlayer->m_Shared.IsInUpgradeZone();
-
+		
 		// check for other popups
-		if ( bInZone && !CHudElement::ShouldDraw() ) 
+		if ( bInZone && !CHudElement::ShouldDraw() )
 		{
 			CTFStatPanel *pStatPanel = GetStatPanel();
 			if ( pStatPanel->IsVisible() )
@@ -493,6 +497,16 @@ bool CHudUpgradePanel::ShouldDraw( void )
 				m_bShowUpgradeMenu = true;
 				m_bCancelUpgrades = false;
 				m_bOpenLoadout = false;
+				#ifdef CLIENT_DLL
+				if (tf_mvm_move_in_shop.GetInt() >= 1)
+				{
+					SetKeyBoardInputEnabled(false);
+				}
+				else
+				{
+					SetKeyBoardInputEnabled(true);
+				}
+				#endif
 			}
 			m_bWasInZone = bInZone;
 		}
@@ -557,7 +571,6 @@ void CHudUpgradePanel::SetActive( bool bActive )
 		// Accept button is disabled till you buy or sell something
 		m_pSelectWeaponPanel->SetControlEnabled( "CloseButton", false );
 
-		SetKeyBoardInputEnabled( false );
 		engine->ClientCmd_Unrestricted( "gameui_preventescapetoshow\n" );
 
 		// Move the mouse cursor to the middle of our panel

--- a/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
+++ b/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
@@ -478,9 +478,9 @@ bool CHudUpgradePanel::ShouldDraw( void )
 		}
 
 		bool bInZone = m_hPlayer->m_Shared.IsInUpgradeZone();
-		
+
 		// check for other popups
-		if ( bInZone && !CHudElement::ShouldDraw() )
+		if ( bInZone && !CHudElement::ShouldDraw() ) 
 		{
 			CTFStatPanel *pStatPanel = GetStatPanel();
 			if ( pStatPanel->IsVisible() )


### PR DESCRIPTION
From what I can tell, the upgrade menu for MVM is supposed to stop movement, for whatever reason it does not.
This PR fixes that and adds a cvar for people who preferred being able to move in the upgrade menu.
I was hoping to also figure out a way for the escape key to close the upgrade menu, but I was unable to get it working.

### Related Issue
N/A

### Implementation
Created cvar for people who preferred how it used to work.
if statement for enabling and disabling movement while in the upgrade menu.
movement is force enabled in the "inspect" upgrade menu

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Built | N/A | Windows 10 Home |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |