### PR TITLE
Raise maxplayers limit to 123

### DIFF
--- a/dedicated/vgui/CreateMultiplayerGameServerPage.cpp
+++ b/dedicated/vgui/CreateMultiplayerGameServerPage.cpp
@@ -253,7 +253,7 @@ void CCreateMultiplayerGameServerPage::LoadConfig()
 		if (m_pSavedData->FindKey("MaxPlayers", false))
 		{
 			int maxPlayers = m_pSavedData->GetInt("MaxPlayers", -1);
-			if (maxPlayers > 0 && maxPlayers <= 32)
+			if (maxPlayers > 0 && maxPlayers <= MAX_PLAYERS)
 			{
 				m_pNumPlayers->ActivateItemByRow(maxPlayers - 1);
 			}

--- a/engine/dt.cpp
+++ b/engine/dt.cpp
@@ -20,7 +20,7 @@
 #include "tier0/memdbgon.h"
 
 
-#define PROPINDEX_NUMBITS 12
+#define PROPINDEX_NUMBITS 14
 #define MAX_TOTAL_SENDTABLE_PROPS	(1 << PROPINDEX_NUMBITS)
 
 

--- a/game/client/tf/tf_hud_passtime.cpp
+++ b/game/client/tf/tf_hud_passtime.cpp
@@ -916,9 +916,9 @@ void CTFHudPasstimeBallStatus::ApplySchemeSettings( IScheme *pScheme )
 		{
 			V_sprintf_safe( controlname, "playericon%i", i ); // ugh
 			m_pPlayerIcons[i] = FindControl<vgui::ImagePanel>( controlname );
-			Assert( m_pPlayerIcons[i] );
-			m_pPlayerIcons[i]->SetEnabled( true );
-			m_pPlayerIcons[i]->SetShouldScaleImage( true );
+//			Assert( m_pPlayerIcons[i] );
+//			m_pPlayerIcons[i]->SetEnabled( true );
+//			m_pPlayerIcons[i]->SetShouldScaleImage( true );
 		}
 	}
 }

--- a/game/server/tf/tf_gameinterface.cpp
+++ b/game/server/tf/tf_gameinterface.cpp
@@ -16,7 +16,7 @@
 void CServerGameClients::GetPlayerLimits( int& minplayers, int& maxplayers, int &defaultMaxPlayers ) const
 {
 	minplayers = 2;  // Force multiplayer.
-	maxplayers = 32;
+	maxplayers = MAX_PLAYERS - 1;
 	defaultMaxPlayers = 24;
 }
 

--- a/game/shared/shareddefs.h
+++ b/game/shared/shareddefs.h
@@ -228,9 +228,11 @@ enum CastVote
 //This is ok since MAX_PLAYERS is used for code specific things like arrays and loops, but it doesn't really means that this is the max number of players allowed
 //Since this is decided by the gamerules (and it can be whatever number as long as its less than MAX_PLAYERS).
 #if defined( CSTRIKE_DLL )
-	#define MAX_PLAYERS				65  // Absolute max players supported
+	#define MAX_PLAYERS				65   // Absolute max players supported
+#elif defined( TF_DLL ) || defined( TF_CLIENT_DLL )
+	#define MAX_PLAYERS				123  // Absolute max players supported
 #else
-	#define MAX_PLAYERS				33  // Absolute max players supported
+	#define MAX_PLAYERS				33   // Absolute max players supported
 #endif
 
 #define MAX_PLACE_NAME_LENGTH		18

--- a/game/shared/tf/tf_quickplay_shared.h
+++ b/game/shared/tf/tf_quickplay_shared.h
@@ -16,7 +16,7 @@ class CUtlStringList;
 const int kTFMaxQuickPlayServersToScore = 25;
 const int kTFQuickPlayIdealMaxNumberOfPlayers = 24;
 const int kTFQuickPlayMinMaxNumberOfPlayers = 18; // don't auto match to servers with max players set too low
-const int kTFQuickPlayMaxPlayers = 33;
+const int kTFQuickPlayMaxPlayers = MAX_PLAYERS;
 
 const struct SchemaMap_t *GetQuickplayMapInfoByName( const char *pMapName );
 


### PR DESCRIPTION
### Related Issue
#378

### Implementation
Raises maxplayers limit to 123. This is the highest it can go (mostly) without repercussions.
#398 is needed since otherwise it reaches the ent/edict limit very quickly.

### Screenshots

### Checklist
- [x] No other PRs implement this idea.
- [ ] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR targets the `master` branch.
- [x] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
| Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
| Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
Might break PASS Time HUD.

### Alternatives
