### PR TITLE
Add tf_weapon_criticals 2 for forced crits

### DIFF
--- a/game/shared/tf/tf_weaponbase.cpp
+++ b/game/shared/tf/tf_weaponbase.cpp
@@ -1375,7 +1375,7 @@ void CTFWeaponBase::CalcIsAttackCritical( void)
 	}
 #endif
 
-	if ( (TFGameRules()->State_Get() == GR_STATE_TEAM_WIN) && (TFGameRules()->GetWinningTeam() == pPlayer->GetTeamNumber()) )
+	if ( (TFGameRules()->State_Get() == GR_STATE_TEAM_WIN) && (TFGameRules()->GetWinningTeam() == pPlayer->GetTeamNumber()) || tf_weapon_criticals.GetInt() >= 2 )
 	{
 		m_bCurrentAttackIsCrit = true;
 	}


### PR DESCRIPTION
This removes the need to use plugins for forced crits.

### Related Issue

### Implementation
Forces critical hits when tf_weapon_criticalsis set to 2.

### Screenshots

### Checklist
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [ ] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats

### Alternatives

