### PR TITLE
Make sv_turbophysics default to 1 instead of setting it

### DIFF
--- a/game/server/props.cpp
+++ b/game/server/props.cpp
@@ -77,7 +77,11 @@ ConVar func_breakdmg_bullet( "func_breakdmg_bullet", "0.5" );
 ConVar func_breakdmg_club( "func_breakdmg_club", "1.5" );
 ConVar func_breakdmg_explosive( "func_breakdmg_explosive", "1.25" );
 
-ConVar sv_turbophysics( "sv_turbophysics", "0", FCVAR_REPLICATED, "Turns on turbo physics" );
+#if defined( TF_DLL ) || defined( TF_CLIENT_DLL )
+	ConVar sv_turbophysics( "sv_turbophysics", "1", FCVAR_REPLICATED, "Turns on turbo physics" );
+#else
+	ConVar sv_turbophysics( "sv_turbophysics", "0", FCVAR_REPLICATED, "Turns on turbo physics" );
+#endif
 
 #ifdef HL2_EPISODIC
 	#define PROP_FLARE_LIFETIME 30.0f

--- a/game/shared/obstacle_pushaway.cpp
+++ b/game/shared/obstacle_pushaway.cpp
@@ -23,7 +23,9 @@ ConVar sv_pushaway_clientside( "sv_pushaway_clientside", "0", SV_PUSH_CONVAR_FLA
 ConVar sv_pushaway_player_force( "sv_pushaway_player_force", "200000", SV_PUSH_CONVAR_FLAGS | FCVAR_CHEAT, "How hard the player is pushed away from physics objects (falls off with inverse square of distance)." );
 ConVar sv_pushaway_max_player_force( "sv_pushaway_max_player_force", "10000", SV_PUSH_CONVAR_FLAGS | FCVAR_CHEAT, "Maximum of how hard the player is pushed away from physics objects." );
 
-#ifdef CLIENT_DLL
+#if defined( TF_CLIENT_DLL )
+ConVar sv_turbophysics( "sv_turbophysics", "1", FCVAR_REPLICATED, "Turns on turbo physics" );
+#elif defined( CLIENT_DLL )
 ConVar sv_turbophysics( "sv_turbophysics", "0", FCVAR_REPLICATED, "Turns on turbo physics" );
 #else
 extern ConVar sv_turbophysics;

--- a/game/shared/tf/tf_gamerules.cpp
+++ b/game/shared/tf/tf_gamerules.cpp
@@ -3158,9 +3158,6 @@ CTFGameRules::CTFGameRules()
 
 	m_bIsInItemTestingMode.Set( false );
 
-	// Set turbo physics on.  Do it here for now.
-	sv_turbophysics.SetValue( 1 );
-
 	// Initialize the team manager here, etc...
 
 	// If you hit these asserts its because you added or removed a weapon type 


### PR DESCRIPTION
### Related Issue

### Implementation
Changes the default of sv_turbophysics to 1 instead of setting it on map start.

### Screenshots

### Checklist
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
It can be turned off, but this can be mitigated by adding a cheat flag.

### Alternatives
