### PR TITLE
Create download_libs.ps1

### DIFF
--- a/download_libs.ps1
+++ b/download_libs.ps1
@@ -1,0 +1,35 @@
+${ErrorActionPreference}  = "Stop"
+
+${server}                 = "https://libs.mastercomfig.com/"
+# $IsWindows was added in PowerShell 6.0, so allow it to be null.
+If (( ${IsWindows} ) -or
+    ( ${IsWindows} -eq $null )) {
+        ${file_extension} = ".exe"
+        ${libraries}      = @(
+            "lib/public/dme_controls.lib"               ;
+            "lib/common/win32/2015/debug/cryptlib.lib"  ;
+            "lib/common/win32/2015/release/cryptlib.lib";
+            "lib/common/x64/2015/debug/cryptlib.lib"    ;
+            "lib/common/x64/2015/release/cryptlib.lib"  ;
+            "lib/common/x64/2015/debug/cryptlib.lib"    )
+}ElseIf ( ${IsLinux} ) {
+    ${libraries}          = @(
+        "lib/common/linux64/libcryptopp.a"              ;
+        "tools/runtime/linux/steamrt_scout_amd64.tar.xz";
+        "tools/runtime/linux/steamrt_scout_i386.tar.xz" )
+}ElseIf ( ${IsmacOS} ) {
+    ${libraries}          = @(
+        "lib/common/osx32/libcryptopp.a"                )
+}
+# curl used to be aliased to Invoke-WebRequest, so add the file extension to avoid conflicts.
+If ( Get-Command -ErrorAction SilentlyContinue curl${file_extension} ) {
+    ForEach ( ${library} in ${libraries} ) {
+        curl${file_extension} ${server}${library} -fLo ${library} --create-dirs
+    }
+}ElseIf ( Get-Command -ErrorAction Continue Invoke-WebRequest ) {
+    ForEach ( ${library} in ${libraries} ) {
+        Invoke-WebRequest ${server}${library} -OutFile ${library}
+    }
+}Else {
+    Throw "Invoke-WebRequest not found. This is likely due to using an outdated version of PowerShell."
+}


### PR DESCRIPTION
### Related Issue

### Implementation
Adds a PowerShell script for systems without curl.

### Screenshots

### Checklist
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
Doesn't work with PowerShell <3.0.

### Alternatives
