### PR TITLE
Training improvements

### DIFF
--- a/game/client/tf/vgui/tf_classmenu.cpp
+++ b/game/client/tf/vgui/tf_classmenu.cpp
@@ -1359,6 +1359,22 @@ void CTFClassMenu::OnCommand( const char *command )
 //-----------------------------------------------------------------------------
 void CTFClassMenu::Join_Class( const CCommand &args )
 {
+	if ( TFGameRules() && TFGameRules()->IsInTraining() )
+	{
+		SetVisible( false );
+
+		CHudNotificationPanel *pNotifyPanel = GET_HUDELEMENT( CHudNotificationPanel );
+		if ( pNotifyPanel )
+		{
+			if ( C_TFPlayer::GetLocalTFPlayer() )
+			{
+				pNotifyPanel->SetupNotifyCustom( "#TF_CantChangeClassNow", "ico_notify_flag_moving", C_TFPlayer::GetLocalTFPlayer()->GetTeamNumber() );
+			}
+		}
+
+		return;
+	}
+
 	if ( args.ArgC() > 1 )
 	{
 		char cmd[256];

--- a/game/server/tf/tf_player.cpp
+++ b/game/server/tf/tf_player.cpp
@@ -4699,7 +4699,8 @@ CEconItemView *CTFPlayer::GetLoadoutItem( int iClass, int iSlot, bool bReportWhi
 			return pItem;
 	}
 
-	if ( TFGameRules()->IsInTraining() || TFGameRules()->IsInItemTestingMode() )
+	extern ConVar training_can_equip_nonstock;
+	if ( ( TFGameRules()->IsInTraining() && ( ( !IsWearableSlot( iSlot ) && training_can_equip_nonstock.GetInt() == 1 ) || !training_can_equip_nonstock.GetBool() ) ) || TFGameRules()->IsInItemTestingMode() )
 	{
 		CTFInventoryManager *pInventoryManager = TFInventoryManager();
 		return pInventoryManager->GetBaseItemForClass( iClass, iSlot );

--- a/game/server/tf/tf_player.cpp
+++ b/game/server/tf/tf_player.cpp
@@ -5975,6 +5975,12 @@ void CTFPlayer::HandleCommand_JoinTeam( const char *pTeamName )
 	if ( TFGameRules()->State_Get() == GR_STATE_GAME_OVER )
 		return;
 
+	if ( TFGameRules() && TFGameRules()->IsInTraining() && !IsFakeClient() )
+	{
+		ClientPrint( this, HUD_PRINTCENTER, "#TF_CantChangeTeamNow" );
+		return;
+	}
+
 	if ( GetTeamNumber() == TF_TEAM_RED || GetTeamNumber() == TF_TEAM_BLUE )
 	{
 		const IMatchGroupDescription* pMatchDesc = GetMatchGroupDescription( TFGameRules()->GetCurrentMatchGroup() );
@@ -7129,6 +7135,12 @@ bool CTFPlayer::ClientCommand( const CCommand &args )
 			return true;
 
 		SetNextChangeClassTime( gpGlobals->curtime + 0.5 );  // limit to one change every 0.5 secs
+
+	 	if ( TFGameRules() && TFGameRules()->IsInTraining() && !IsFakeClient() )
+	 	{
+	 		ClientPrint( this, HUD_PRINTCENTER, "#TF_CantChangeClassNow" );
+	 		return true;
+	 	}
 
 		if ( tf_arena_force_class.GetBool() == false )
 		{

--- a/game/shared/tf/tf_gamerules.cpp
+++ b/game/shared/tf/tf_gamerules.cpp
@@ -385,6 +385,7 @@ ConVar training_can_select_weapon_building	( "training_can_select_weapon_buildin
 ConVar training_can_select_weapon_pda		( "training_can_select_weapon_pda", "1", FCVAR_REPLICATED, "In training player select pda." );
 ConVar training_can_select_weapon_item1		( "training_can_select_weapon_item1", "1", FCVAR_REPLICATED, "In training player select item 1." );
 ConVar training_can_select_weapon_item2		( "training_can_select_weapon_item2", "1", FCVAR_REPLICATED, "In training player select item 2." );
+ConVar training_can_equip_nonstock			( "training_can_equip_nonstock", "1", FCVAR_CHEAT | FCVAR_REPLICATED, "In training player equip non-stock." );
 
 ConVar tf_birthday_ball_chance( "tf_birthday_ball_chance", "100", FCVAR_REPLICATED, "Percent chance of a birthday beach ball spawning at each round start" );
 

--- a/game/shared/tf/tf_gamerules.cpp
+++ b/game/shared/tf/tf_gamerules.cpp
@@ -4105,6 +4105,7 @@ void CTFGameRules::Activate()
 		m_bIsInTraining.Set( true );
 		m_bAllowTrainingAchievements.Set( false );
 		mp_humans_must_join_team.SetValue( "blue" );
+		mp_allowspectators.SetValue( "0.0" );
 		m_bIsTrainingHUDVisible.Set( true );
 		tf_training_client_message.SetValue( (int)TRAINING_CLIENT_MESSAGE_NONE );
 	}
@@ -7604,6 +7605,7 @@ void CTFGameRules::LevelShutdown()
 	if ( IsInTraining() )
 	{
 		mp_humans_must_join_team.SetValue( "any" );
+		mp_allowspectators.SetValue( "1.0" );
 		training_can_build_sentry.Revert();
 		training_can_build_dispenser.Revert();
 		training_can_build_tele_entrance.Revert();


### PR DESCRIPTION
### Related Issue

### Implementation
Blocks `jointeam`, `spectate`, and `join(_)class` in training.

Allow cosmetics and taunts to be used in training. The new convar `training_can_use_nonstock` controls this;
* 0 (old behavior) = No non-stock items allowed.
* 1 (default) = Cosmetics and taunts allowed.
* 2 = All non-stock items allowed.

The only [sets](https://wiki.teamfortress.com/wiki/Item_sets) that work don't notably change balance.

Full stock is still used in itemtest mode.

### Screenshots

### Checklist
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
Map has to be restarted if changing cvar to 0 from 1 or 2.

### Alternatives
