### PR TITLE
Fix cut off usernames (#58)

### DIFF
--- a/public/const.h
+++ b/public/const.h
@@ -38,7 +38,7 @@
 
 // a player name may have 31 chars + 0 on the PC.
 // the 360 only allows 15 char + 0, but stick with the larger PC size for cross-platform communication
-#define MAX_PLAYER_NAME_LENGTH		32
+#define MAX_PLAYER_NAME_LENGTH		33
 
 #ifdef _X360
 #define MAX_PLAYERS_PER_CLIENT		XUSER_MAX_COUNT	// Xbox 360 supports 4 players per console


### PR DESCRIPTION
### Related Issue
#58

### Implementation
Raises `MAX_PLAYER_NAME_LENGTH` to 33. This comment suggests it might be a proper fix: https://github.com/mastercomfig/team-comtress-2/blob/213be2ea75a491fc44aae03b96e3d142730ca38d/public/const.h#L39

Not sure why this is here:
https://github.com/mastercomfig/team-comtress-2/blob/213be2ea75a491fc44aae03b96e3d142730ca38d/game/server/NextBot/NextBotBehavior.h#L571

Other code I thought might be the culprit, but weren't:
https://github.com/mastercomfig/team-comtress-2/blob/213be2ea75a491fc44aae03b96e3d142730ca38d/game/shared/tf/tf_gamerules.cpp#L9974 https://github.com/mastercomfig/team-comtress-2/blob/213be2ea75a491fc44aae03b96e3d142730ca38d/engine/baseclient.cpp#L567
X360-only code:
https://github.com/mastercomfig/team-comtress-2/blob/213be2ea75a491fc44aae03b96e3d142730ca38d/engine/matchmakingshared.cpp#L796

Aside from checking the cvar, I also made sure names weren't cut off in the chat (voice commands, name changes, and messages), on bots, in the console, and in the killfeed.

### Screenshots
#### Before:
![](https://user-images.githubusercontent.com/3462541/98361887-30b1e680-1fe1-11eb-832a-862e641e298b.png)
![](https://user-images.githubusercontent.com/3462541/98366177-63aba880-1fe8-11eb-9c7e-51b9e230b6f9.png)
![](https://user-images.githubusercontent.com/3462541/98366391-bedd9b00-1fe8-11eb-81c1-b39cab2ee90b.png)
![](https://user-images.githubusercontent.com/3462541/98366495-f0eefd00-1fe8-11eb-9e04-5e6d9e5a276c.png)
#### After:
![](https://user-images.githubusercontent.com/3462541/98362986-16790800-1fe3-11eb-9d3e-4ae25e6e555f.png)
![](https://user-images.githubusercontent.com/3462541/98363295-943d1380-1fe3-11eb-8e2c-13a4c30bfe86.png)
![](https://user-images.githubusercontent.com/3462541/98363555-fb5ac800-1fe3-11eb-8cc5-c750e68bb30b.png)
![](https://user-images.githubusercontent.com/3462541/98363703-41b02700-1fe4-11eb-9b1a-8c3590a50a12.png)

### Checklist
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR targets the `master` branch.
- [x] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
Might not be a proper fix.

### Alternatives
