### PR TITLE
Make mat_filtertextures 0 apply to all textures

### DIFF
--- a/materialsystem/shaderapidx9/shaderapidx8.cpp
+++ b/materialsystem/shaderapidx9/shaderapidx8.cpp
@@ -6883,7 +6883,7 @@ void CShaderAPIDx8::SetTextureState( Sampler_t sampler, ShaderAPITextureHandle_t
 		mipFilter = D3DTEXF_NONE;
 	} 
 
-	if ( materialSystemConfig.bFilterTextures == 0 && tex.m_NumLevels > 1 ) 
+	if ( materialSystemConfig.bFilterTextures == 0 /*&& tex.m_NumLevels > 1*/ )
 	{
 		minFilter = D3DTEXF_NONE;
 		magFilter = D3DTEXF_NONE;


### PR DESCRIPTION
### Related Issue

### Implementation
Makes mat_filtertextures 0 apply to all textures.

### Screenshots

### Checklist
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
This might've been done due to issues I didn't experience during testing.

### Alternatives
