### PR TITLE
Allow stretching with r_aspectratio

### DIFF
--- a/engine/gl_rmain.cpp
+++ b/engine/gl_rmain.cpp
@@ -42,11 +42,7 @@
 extern ConVar r_waterforceexpensive;
 #endif
 
-ConVar r_aspectratio( "r_aspectratio", "0" 
-#if !defined( _X360 )
-					 , FCVAR_CHEAT
-#endif
-					 );
+ConVar r_aspectratio( "r_aspectratio", "0" );
 ConVar r_dynamiclighting( "r_dynamiclighting", "1", FCVAR_CHEAT );
 extern ConVar building_cubemaps;
 extern float scr_demo_override_fov;	
@@ -124,17 +120,29 @@ void PerpendicularVector( Vector& dst, const Vector& src )
 //-----------------------------------------------------------------------------
 float GetScreenAspect( )
 {
-	// use the override if set
-	if ( r_aspectratio.GetFloat() > 0.0f )
-		return r_aspectratio.GetFloat();
-
 	// mikesart: This is just sticking in unnecessary BeginRender/EndRender calls to the queue.
 	//   CMatRenderContextPtr pRenderContext( materials );
 	IMatRenderContext *pRenderContext = g_pMaterialSystem->GetRenderContext();
 
 	int width, height;
 	pRenderContext->GetRenderTargetDimensions( width, height );
-	return (height != 0) ? ( (float)width / (float)height ) : 1.0f;
+	float aspectratio = (height != 0) ? ( (float)width / (float)height ) : 1.0f;
+
+	// use the override if set
+	if ( r_aspectratio.GetFloat() != 0.0f )
+	{
+		extern ConVar sv_cheats;
+		if ( ( r_aspectratio.GetFloat() <= aspectratio && r_aspectratio.GetFloat() > 0 ) || sv_cheats.GetInt() )
+		{
+			return r_aspectratio.GetFloat();
+		}
+		else
+		{
+			ConMsg( "r_aspectratio was set wider than the native aspect ratio, or less than 0 without sv_cheats... Reverting.\n" );
+			r_aspectratio.SetValue( "0" );
+		}
+	}
+	return aspectratio;
 }
 
 


### PR DESCRIPTION
### Related Issue

### Implementation
Allows stretching without lowering the resolution.
r_aspectratio cannot be set wider than the native aspect ratio, or less than 0 without sv_cheats.

### Screenshots

### Checklist
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
A very small value (e.g. 0.001) might be exploitable.
2D/HUD elements like the crosshair aren't scaled.

### Alternatives
