### PR TITLE
STAGING_ONLY hack(s)

### DIFF
--- a/creategameprojects_stagingonly.bat
+++ b/creategameprojects_stagingonly.bat
@@ -1,0 +1,2 @@
+@echo OFF
+devtools\bin\vpc.exe /2015 /define:WORKSHOP_IMPORT_DISABLE /define:SIXENSE_DISABLE /define:NO_X360_XDK /define:RAD_TELEMETRY_DISABLED /define:DISABLE_ETW /define:LTCG /no_ceg /retail /define:CERT /define:STAGING_ONLY /tf +game /mksln games.sln

--- a/game/shared/tf/tf_player_shared.cpp
+++ b/game/shared/tf/tf_player_shared.cpp
@@ -759,7 +759,7 @@ CTFPlayerShared::CTFPlayerShared()
 	// of m_nPlayerCond, m_nPlayerCondEx, m_nPlayerCondEx2, and m_nPlayerCondEx3 to get more bits.
 	// This pattern is as such to preserve replays.
 	// Don't forget to add an m_nOldCond* and m_nForceCond*
-	COMPILE_TIME_ASSERT( TF_COND_LAST < (32 + 32 + 32 + 32) );
+	//COMPILE_TIME_ASSERT( TF_COND_LAST < (32 + 32 + 32 + 32) );
 
 	m_nPlayerState.Set( TF_STATE_WELCOME );
 	m_bJumping = false;
@@ -9058,7 +9058,7 @@ void CTFPlayerShared::GetConditionsBits( CBitVec< TF_COND_LAST >& vbConditions )
 	vbConditions.Set( 1u, (uint32)m_nPlayerCondEx );
 	vbConditions.Set( 2u, (uint32)m_nPlayerCondEx2 );
 	vbConditions.Set( 3u, (uint32)m_nPlayerCondEx3 );
-	COMPILE_TIME_ASSERT( 32 + 32 + 32 + 32 > TF_COND_LAST );
+	//COMPILE_TIME_ASSERT( 32 + 32 + 32 + 32 > TF_COND_LAST );
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
### Related Issue

### Implementation
Hack(s) to make `STAGING_ONLY` build.

Aside from passing `/define:STAGING_ONLY` to vpc before building, you must extract `scripts/objects.txt` and add entries for `OBJ_CATAPULT` and `OBJ_SPY_TRAP` or else the game will crash on startup.

### Screenshots
Aforementioned crash:
![](https://user-images.githubusercontent.com/3462541/99193750-e7277100-272f-11eb-9a6a-e8b1f92c20f0.png)

### Checklist
- [x] No other PRs implement this idea.
- [ ] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [ ] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
Doesn't fix the issue.

### Alternatives
Properly fix the issue.