### PR TITLE
Hopefully fix the invincible sapper glitch

### DIFF
--- a/game/server/tf/tf_obj_sapper.cpp
+++ b/game/server/tf/tf_obj_sapper.cpp
@@ -199,26 +199,29 @@ void CObjectSapper::FinishedBuilding( void )
 	BaseClass::FinishedBuilding();
 
 	CBaseEntity *pEntity =  m_hBuiltOnEntity.Get();
-	if ( pEntity )
+	if (pEntity)
 	{
-		if ( GetParentObject() )
+		if (!IsPlacing())
 		{
-			GetParentObject()->OnAddSapper();
-
-			CBaseObject *pObject = dynamic_cast<CBaseObject *>( m_hBuiltOnEntity.Get() );
-			if ( pObject )
+			if (GetParentObject())
 			{
-				if ( GetBuilder() && pObject->GetBuilder() )
-				{
-					IGameEvent * event = gameeventmanager->CreateEvent( "player_sapped_object" );
-					if ( event )
-					{
-						event->SetInt( "userid", GetBuilder()->GetUserID() );
-						event->SetInt( "ownerid", pObject->GetBuilder()->GetUserID() );
-						event->SetInt( "object", pObject->ObjectType() );
-						event->SetInt( "sapperid", entindex() );
+				GetParentObject()->OnAddSapper();
 
-						gameeventmanager->FireEvent( event );
+				CBaseObject* pObject = dynamic_cast<CBaseObject*>(m_hBuiltOnEntity.Get());
+				if (pObject)
+				{
+					if (GetBuilder() && pObject->GetBuilder())
+					{
+						IGameEvent* event = gameeventmanager->CreateEvent("player_sapped_object");
+						if (event)
+						{
+							event->SetInt("userid", GetBuilder()->GetUserID());
+							event->SetInt("ownerid", pObject->GetBuilder()->GetUserID());
+							event->SetInt("object", pObject->ObjectType());
+							event->SetInt("sapperid", entindex());
+							
+							gameeventmanager->FireEvent(event);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This might not work, I wasn't able to set up a consistent way to test it.

### Implementation
Add a check before placing the sapper for `!IsPlacing()`, which in theory should make it so that the sapper checks if there is already a sapper being placed on the building.

### Steps to reproduce
1. Have 2 players, and engi and a spy
2. Engi builds a building and puts just enough metal that 1 swing would upgrade it (175-199 metal)
3. Spy starts to sap building (I tried to time it off of the engi's swing that would upgrade the building"
4. during the 1/10 of a second build time for the sapper, the engi would upgrade the building (this timing is _VERY tight_)
5. Place a second sapper while the building is still upgrading (you'll know if you can do this because the building placing outline will be on top of the already built sapper)

### Screenshots
<!-- Add screenshots if applicable -->

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] This PR targets the `master` branch.
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Tested | N/A | Windows 10 Home |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
None known

### Alternatives
1. Have m_bHasSapper double check if there is still a sapper on the building after a sapper is removed (doesn't fix the issue of the double sapper, but does fix the invincible sapper)
2. Hack-y solution that adds a slight cooldown to saps
3. Hack-y solution that makes it so that you can't place sappers on upgrading buildings, or that when upgrading, the sapper gets deleted.
