### PR TITLE
PVS-Studio analyzer warning fixes

### DIFF
--- a/public/bspfile.h
+++ b/public/bspfile.h
@@ -794,7 +794,8 @@ struct dfaceid_t
 #if defined( _X360 )
 #pragma bitfield_order( push, lsb_to_msb )
 #endif
-#pragma warning( disable:4201 )	// C4201: nonstandard extension used: nameless struct/union
+#pragma warning( push )
+#pragma warning( disable: 4201 ) // C4201: nonstandard extension used: nameless struct/union
 struct dleaf_version_0_t
 {
 	DECLARE_BYTESWAP_DATADESC();
@@ -848,7 +849,7 @@ struct dleaf_t
 	// Precaculated light info for entities.
 //	CompressedLightCube m_AmbientLighting;
 };
-#pragma warning( default:4201 )	// C4201: nonstandard extension used: nameless struct/union
+#pragma warning( pop )	// C4201: nonstandard extension used: nameless struct/union
 #if defined( _X360 )
 #pragma bitfield_order( pop )
 #endif

--- a/public/filesystem_passthru.h
+++ b/public/filesystem_passthru.h
@@ -202,7 +202,7 @@ public:
 	virtual bool			GetFileTypeForFullPath( char const *pFullPath, wchar_t *buf, size_t bufSizeInBytes ) { return m_pFileSystemPassThru->GetFileTypeForFullPath( pFullPath, buf, bufSizeInBytes ); }
 
 	virtual bool			GetOptimalIOConstraints( FileHandle_t hFile, unsigned *pOffsetAlign, unsigned *pSizeAlign, unsigned *pBufferAlign ) { return m_pFileSystemPassThru->GetOptimalIOConstraints( hFile, pOffsetAlign, pSizeAlign, pBufferAlign ); }
-	virtual void			*AllocOptimalReadBuffer( FileHandle_t hFile, unsigned nSize, unsigned nOffset  ) { return m_pFileSystemPassThru->AllocOptimalReadBuffer( hFile, nOffset, nSize ); }
+	virtual void			*AllocOptimalReadBuffer( FileHandle_t hFile, unsigned nSize, unsigned nOffset  ) { return m_pFileSystemPassThru->AllocOptimalReadBuffer( hFile, nSize, nOffset ); }
 	virtual void			FreeOptimalReadBuffer( void *p ) { m_pFileSystemPassThru->FreeOptimalReadBuffer( p ); }
 
 	virtual void			BeginMapAccess() { m_pFileSystemPassThru->BeginMapAccess(); }

--- a/public/tier0/tslist.h
+++ b/public/tier0/tslist.h
@@ -670,7 +670,7 @@ public:
 		}
 
 		Node_t() {}
-		Node_t( const T &init ) : elem( init ) {}
+		Node_t( const T &init ) : pNext( nullptr ), elem( init ) {}
 
 		Node_t *pNext;
 		T elem;

--- a/public/tier1/convar.h
+++ b/public/tier1/convar.h
@@ -627,7 +627,8 @@ void ConVar_PrintDescription( const ConCommandBase *pVar );
 //-----------------------------------------------------------------------------
 // Purpose: Utility class to quickly allow ConCommands to call member methods
 //-----------------------------------------------------------------------------
-#pragma warning (disable : 4355 )
+#pragma warning( push )
+#pragma warning( disable: 4355 )
 
 template< class T >
 class CConCommandMemberAccessor : public ConCommand, public ICommandCallback, public ICommandCompletionCallback
@@ -674,7 +675,7 @@ private:
 	FnMemberCommandCompletionCallback_t m_CompletionFunc;
 };
 
-#pragma warning ( default : 4355 )
+#pragma warning( pop )
 
 
 //-----------------------------------------------------------------------------

--- a/public/tier1/strtools.h
+++ b/public/tier1/strtools.h
@@ -1284,5 +1284,7 @@ size_t Q_URLDecode( OUT_CAP(nDecodeDestLen) char *pchDecodeDest, int nDecodeDest
 // Strip white space at the beginning and end of a string
 int V_StrTrim( char *pStr );
 
+void V_SecureClean( void *pBuf, size_t len );
+
 
 #endif	// TIER1_STRTOOLS_H

--- a/tier0/memdbg.cpp
+++ b/tier0/memdbg.cpp
@@ -737,7 +737,7 @@ static void DefaultHeapReportFunc( char const *pFormat, ... )
 //-----------------------------------------------------------------------------
 // Constructor
 //-----------------------------------------------------------------------------
-CDbgMemAlloc::CDbgMemAlloc() : m_sMemoryAllocFailed( (size_t)0 )
+CDbgMemAlloc::CDbgMemAlloc() : m_pStatMap( nullptr ), m_pFilenames( nullptr ), m_sMemoryAllocFailed( (size_t)0 )
 {
 	// Make sure that we return 64-bit addresses in 64-bit builds.
 	ReserveBottomMemory();

--- a/tier0/stacktools.cpp
+++ b/tier0/stacktools.cpp
@@ -374,6 +374,7 @@ public:
 	{
 		m_bIsInitialized = false;
 		m_bShouldReloadSymbols = false;
+		m_hProcess = nullptr;
 		m_hDbgHelpDll = NULL;
 		m_szPDBSearchPath = NULL;
 		m_pSymInitialize = SymInitialize_DummyFn;

--- a/tier0/threadtools.cpp
+++ b/tier0/threadtools.cpp
@@ -2047,6 +2047,7 @@ CThread::CThread()
 #endif
 	m_threadId( 0 ),
 	m_result( 0 ),
+	m_pStackBase( nullptr ),
 	m_flags( 0 )
 {
 	m_szName[0] = 0;

--- a/tier1/KeyValues.cpp
+++ b/tier1/KeyValues.cpp
@@ -534,7 +534,8 @@ const char *KeyValues::GetName( void ) const
 //-----------------------------------------------------------------------------
 // Purpose: Read a single token from buffer (0 terminated)
 //-----------------------------------------------------------------------------
-#pragma warning (disable:4706)
+#pragma warning( push )
+#pragma warning( disable: 4706 )
 const char *KeyValues::ReadToken( CUtlBuffer &buf, bool &wasQuoted, bool &wasConditional )
 {
 	wasQuoted = false;
@@ -618,7 +619,7 @@ const char *KeyValues::ReadToken( CUtlBuffer &buf, bool &wasQuoted, bool &wasCon
 	s_pTokenBuf[ nCount ] = 0;
 	return s_pTokenBuf;
 }
-#pragma warning (default:4706)
+#pragma warning( pop )
 
 	
 

--- a/tier1/checksum_sha1.cpp
+++ b/tier1/checksum_sha1.cpp
@@ -23,12 +23,14 @@
 
 #if !defined(_MINIMUM_BUILD_)
 #include "checksum_sha1.h"
+#include "strtools.h"
 #else
 //
 //	This path is build in the CEG/DRM projects where we require that no CRT references are made !
 //
 #include <intrin.h>				// memcpy, memset etc... will be inlined.
 #include "tier1/checksum_sha1.h"
+#include "tier1/strtools.h"
 #endif
 
 #define MAX_FILE_READ_BUFFER 8000
@@ -238,8 +240,8 @@ void CSHA1::Final()
 	i = 0;
 	memset(m_buffer, 0, sizeof(m_buffer) );
 	memset(m_state, 0, sizeof(m_state) );
-	memset(m_count, 0, sizeof(m_count) );
-	memset(finalcount, 0, sizeof( finalcount) );
+	V_SecureClean(m_count, sizeof(m_count) );
+	V_SecureClean(finalcount, sizeof(finalcount) );
 
 	Transform(m_state, m_buffer);
 }

--- a/tier1/commandbuffer.cpp
+++ b/tier1/commandbuffer.cpp
@@ -30,13 +30,16 @@ struct cmdalias_t
 //-----------------------------------------------------------------------------
 CCommandBuffer::CCommandBuffer( ) : m_Commands( 32, 32 )
 {
-	m_hNextCommand = m_Commands.InvalidIndex();
-	m_nWaitDelayTicks = 1;
+	m_pArgSBuffer[0] = '\0';
+	m_nLastUsedArgSSize = -1;
+	m_nArgSBufferSize = 0;
 	m_nCurrentTick = 0;
 	m_nLastTickToProcess = -1;
-	m_nArgSBufferSize = 0;
-	m_bIsProcessingCommands = false;
+	m_nWaitDelayTicks = 1;
+	m_hNextCommand = m_Commands.InvalidIndex();
 	m_nMaxArgSBufferLength = ARGS_BUFFER_LENGTH;
+	m_bIsProcessingCommands = false;
+	m_bWaitEnabled = false;
 }
 
 CCommandBuffer::~CCommandBuffer()

--- a/tier1/strtools.cpp
+++ b/tier1/strtools.cpp
@@ -3216,6 +3216,15 @@ int V_StrTrim( char *pStr )
 	return pDest - pStart;
 }
 
+// Prevent compiler from inlining memset and further removal if V_SecureClean buffer
+// is not accessed later.
+static volatile auto memset_func = memset;
+
+void V_SecureClean( void *pBuf, size_t len )
+{
+	memset_func( pBuf, 0, len );
+}
+
 #ifdef _WIN32
 int64 V_strtoi64( const char *nptr, char **endptr, int base )
 {

--- a/tier1/strtools_unicode.cpp
+++ b/tier1/strtools_unicode.cpp
@@ -262,7 +262,6 @@ namespace // internal use only
 					}
 					else if ( ePolicy & _STRINGCONVERTFLAG_FAIL )
 					{
-						pOut[0] = 0;
 						return 0;
 					}
 				}

--- a/tier1/utlbuffer.cpp
+++ b/tier1/utlbuffer.cpp
@@ -905,7 +905,8 @@ void CUtlBuffer::SeekGet( SeekType_t type, int offset )
 // Parse...
 //-----------------------------------------------------------------------------
 
-#pragma warning ( disable : 4706 )
+#pragma warning( push )
+#pragma warning( disable: 4706 )
 
 int CUtlBuffer::VaScanf( const char* pFmt, va_list list )
 {
@@ -1076,7 +1077,7 @@ int CUtlBuffer::VaScanf( const char* pFmt, va_list list )
 	return numScanned;
 }
 
-#pragma warning ( default : 4706 )
+#pragma warning ( pop )
 
 int CUtlBuffer::Scanf( const char* pFmt, ... )
 {

--- a/tier2/keyvaluesmacros.cpp
+++ b/tier2/keyvaluesmacros.cpp
@@ -130,7 +130,7 @@ static KeyValues *HandleKeyValuesMacro_Insert( KeyValues *pkvInsert, KeyValues *
 	}
 
 	const char *pszInsert = pkvInsert->GetString();
-	if ( !pszInsert && *pszInsert == '\0' )
+	if ( !pszInsert || *pszInsert == '\0' )
 	{
 		// Invalid, value is empty string
 		Msg( "Error: #insert on key with empty string value, can only do #insert with simple key/value with string value\n" );


### PR DESCRIPTION
### Related Issue
* None

### Implementation
Just PVS-Studio static analyzer warning fixes. 

Secure memory clean function `V_SecureClean` based on idea from https://git.openssl.org/?p=openssl.git;a=blob;f=crypto/mem_clr.c, but i'm not sure it should be mentioned here, because it is just idea, not implementation.

Product page: https://www.viva64.com/en/pvs-studio/
How to use for free: https://www.viva64.com/en/b/0600/

### Screenshots
None

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [ ] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR only contains changes to the engine and/or core game framework
- [x] This PR targets the `community` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [ ] This change has been filed as an issue.
- [ ] No other PRs address this.
- [ ] This PR is as minimal as possible.
- [ ] This PR does not introduce any regressions.
- [ ] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- N/A --> | <!-- N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | <!-- N/A --> | <!-- N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- N/A --> | <!-- N/A --> | <!-- e.g. Catalina -->      |

### Caveats
Not known.

### Alternatives
Not known.
