### PR TITLE
Low health alert shows for mini-sentries

### DIFF
--- a/game/client/tf/tf_hud_building_status.cpp
+++ b/game/client/tf/tf_hud_building_status.cpp
@@ -388,10 +388,10 @@ void CBuildingStatusItem::OnTick()
 			m_pWrenchIcon->SetVisible( bAlertTrayFullyDeployed );
 			break;
 
-			// do not show low health for mini-sentry
+			// show building health for normal sentry and mini-sentry
 		case BUILDING_HUD_ALERT_LOW_HEALTH:
 		case BUILDING_HUD_ALERT_VERY_LOW_HEALTH:
-			bShowAlertTray = pObj->IsMiniBuilding() == false;
+			bShowAlertTray = true;
 			m_pWrenchIcon->SetVisible( bAlertTrayFullyDeployed && bShowAlertTray );
 			break;
 


### PR DESCRIPTION
Issue#516
When gunslinger was changed to allow repairing of mini sentries Valve did not change the alert to show mini-sentry at low health. This change now shows the low health alert for both types of sentries.

**FIRST CONTRIBUTION, FEEDBACK APPRECIATED

### Related Issue
#516 

### Implementation
Changed within \game\client\tf\tf_hud_building_status.cpp

**Original**
```
		case BUILDING_HUD_ALERT_LOW_HEALTH:
		case BUILDING_HUD_ALERT_VERY_LOW_HEALTH:
			bShowAlertTray = pObj->IsMiniBuilding() == false;
			m_pWrenchIcon->SetVisible( bAlertTrayFullyDeployed && bShowAlertTray );
			break;
```

**New**
```
		case BUILDING_HUD_ALERT_LOW_HEALTH:
		case BUILDING_HUD_ALERT_VERY_LOW_HEALTH:
			bShowAlertTray = true;
			m_pWrenchIcon->SetVisible( bAlertTrayFullyDeployed && bShowAlertTray );
			break;
```

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR only contains changes to the engine and/or core game framework
- [x] This PR targets the `community` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [ ] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats

### Alternatives
In the issue it was suggested to keep this feature, as mini-sentries typically are not repaired. However, to keep consistency with regular sentry behaviour this seems logical.
