### PR TITLE
Huntsman dropped weapon fix

### DIFF
--- a/game/shared/tf/tf_dropped_weapon.cpp
+++ b/game/shared/tf/tf_dropped_weapon.cpp
@@ -67,7 +67,6 @@ CTFDroppedWeapon::CTFDroppedWeapon()
 #endif // CLIENT_DLL
 
 	m_flChargeLevel.Set( 0.f );
-	m_flChargeBeginTime.Set( 0.f );
 }
 
 //-----------------------------------------------------------------------------

--- a/game/shared/tf/tf_dropped_weapon.cpp
+++ b/game/shared/tf/tf_dropped_weapon.cpp
@@ -18,6 +18,7 @@
 #include "tf_player.h"
 #include "tf_weaponbase.h"
 #include "tf_weapon_medigun.h"
+#include "tf_weapon_compound_bow.h"
 #include "tf_gamerules.h"
 #include "tf_weapon_bottle.h"
 #endif // GAME_DLL
@@ -66,6 +67,7 @@ CTFDroppedWeapon::CTFDroppedWeapon()
 #endif // CLIENT_DLL
 
 	m_flChargeLevel.Set( 0.f );
+	m_flChargeBeginTime.Set( 0.f );
 }
 
 //-----------------------------------------------------------------------------
@@ -601,6 +603,12 @@ void CTFDroppedWeapon::InitPickedUpWeapon( CTFPlayer *pPlayer, CTFWeaponBase *pW
 	// Make sure engineer don't gain metal by picking up weapon
 	pPlayer->SetAmmoCount( nCurrentMetal, TF_AMMO_METAL );
 	pWeapon->Energy_SetEnergy( m_flEnergy );
+
+	CTFCompoundBow *pCompoundBow = dynamic_cast< CTFCompoundBow* >( pWeapon );
+	if ( pCompoundBow )
+	{
+		pCompoundBow->WeaponReset();
+	}
 
 	CWeaponMedigun *pMedigun = dynamic_cast< CWeaponMedigun* >( pWeapon );
 	if ( pMedigun )


### PR DESCRIPTION
Issue #483

Added on weapon pickup, huntsman (compound bow) call to WeaponReset(). This should reset m_flChargeBeginTime to 0.f, which previously wasn't reset upon picking up a pulled back Huntsman. This should allow the person who picked the weapon up to jump.

### Related Issue
#483 

### Implementation
Upon weapon pickup, a call is made to WeaponReset() with CTFCompoundBow. This resets m_flChargeBeginTime to 0.f. I have only added this call upon weapon pickup, maybe this should be also added when the weapon is dropped?

### Screenshots
<!-- Add screenshots if applicable -->

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR only contains changes to the engine and/or core game framework
- [x] This PR targets the `community` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] This change has been filed as an issue.
- [x] No other PRs address this.
- [ ] This PR is as minimal as possible.
- [ ] This PR does not introduce any regressions.
- [ ] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
This is entirely untested, I have not got around to building with this version and checking this. If someone wants to add me on Discord to run me through building, and then testing this on a server with me then please get in touch.

### Alternatives
This could be implemented in the weapon being dropped, which probably makes more sense. For instance, when the weapon is on fire and dropped you'd expect the fire to go out when the weapon is dropped - not when it is picked up.
