### PR TITLE
[MVM] Removed damage and heal on kill upgrades for rocket jumper and sticky jumper

### DIFF
--- a/game/shared/tf/tf_gamerules.cpp
+++ b/game/shared/tf/tf_gamerules.cpp
@@ -21166,6 +21166,11 @@ bool CTFGameRules::CanUpgradeWithAttrib( CTFPlayer *pPlayer, int iWeaponSlot, at
 			if ( bHideDmgUpgrades )
 				return false;
 
+			// No damage bonus on rocket jumper or sticky jumper
+			if (( iWeaponID == TF_WEAPON_ROCKETLAUNCHER && !pPlayer->IsAllowedToPickUpFlag() ) ||
+				( iWeaponID == TF_WEAPON_PIPEBOMBLAUNCHER && !pPlayer->IsAllowedToPickUpFlag() ) )
+				return false;
+
 			// Some classes get a weaker dmg upgrade
 			if ( nQuality == MVM_UPGRADE_QUALITY_LOW )
 			{
@@ -21224,6 +21229,12 @@ bool CTFGameRules::CanUpgradeWithAttrib( CTFPlayer *pPlayer, int iWeaponSlot, at
 		break;
 	// case 8:		// "heal rate bonus"
 	case 10:	// "ubercharge rate bonus"
+	case 180:	// "heal on kill"
+		{
+			return ( !( iWeaponID == TF_WEAPON_ROCKETLAUNCHER && !pPlayer->IsAllowedToPickUpFlag() ) ||
+					 !( iWeaponID == TF_WEAPON_PIPEBOMBLAUNCHER && !pPlayer->IsAllowedToPickUpFlag() ) );
+		}
+		break;
 	case 314:	// "uber duration bonus"
 	case 481:	// "canteen specialist"
 	case 482:	// "overheal expert"


### PR DESCRIPTION
Removed these upgrades being displayed for the rocket and sticky jumper, this is untested.

### Related Issue
Issue #511 

### Implementation
Additional checks for both of these upgrades are made to prevent these upgrades being offered whilst equipping these weapons, picked up from @TrickyTrix935 comments on the original issue page.

### Screenshots
<!-- Add screenshots if applicable -->

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR only contains changes to the engine and/or core game framework
- [x] This PR targets the `community` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [ ] This PR does not introduce any regressions.
- [ ] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
Implementation could do with reviewing, I tried to follow similar style to Valve but this might have just lead to less readable code. This could be changed.

### Alternatives
There is currently:

`	// Hack to simplify excluding non-weapons from damage upgrades
	bool bHideDmgUpgrades = iWeaponID == TF_WEAPON_NONE || 
							iWeaponID == TF_WEAPON_LASER_POINTER || 
							iWeaponID == TF_WEAPON_MEDIGUN || 
							iWeaponID == TF_WEAPON_BUFF_ITEM ||
							iWeaponID == TF_WEAPON_BUILDER ||
							iWeaponID == TF_WEAPON_PDA_ENGINEER_BUILD ||
							iWeaponID == TF_WEAPON_INVIS ||
							iWeaponID == TF_WEAPON_SPELLBOOK;`

Where this fix could have been added, which might be more neat / readable then the proposed changes.
