### PR TITLE
Fixed not being able to change item meter color and removing reference to an unused file.

### DIFF
--- a/game/client/tf/tf_hud_itemeffectmeter.cpp
+++ b/game/client/tf/tf_hud_itemeffectmeter.cpp
@@ -284,7 +284,7 @@ void CHudItemEffectMeter::CreateHudElementsForClass( C_TFPlayer* pPlayer, CUtlVe
 	}
 
 	// ALL CLASS
-	DECLARE_ITEM_EFFECT_METER( CTFThrowable, TF_WEAPON_THROWABLE, true, "resource/UI/HudItemEffectMeter_Action.res" );
+	//DECLARE_ITEM_EFFECT_METER( CTFThrowable, TF_WEAPON_THROWABLE, true, "resource/UI/HudItemEffectMeter_Action.res" );
 
 	// Kill Streak
 	DECLARE_ITEM_EFFECT_METER( CTFWeaponBase, TF_WEAPON_NONE, false, "resource/UI/HudItemEffectMeter_KillStreak.res" );

--- a/game/client/tf/tf_hud_itemeffectmeter.cpp
+++ b/game/client/tf/tf_hud_itemeffectmeter.cpp
@@ -475,18 +475,6 @@ void CHudItemEffectMeter::Update( C_TFPlayer* pPlayer, const char* pSoundScript 
 
 	// Update the meter GUI element.
 	m_pProgressBar->SetProgress( flProgress );
-
-	// Flash the bar if this class implementation requires it.
-	if ( ShouldFlash() )
-	{
-		int color_offset = ((int)(gpGlobals->realtime*10)) % 10;
-		int red = 160 + (color_offset*10);
-		m_pProgressBar->SetFgColor( Color( red, 0, 0, 255 ) );
-	}
-	else
-	{
-		m_pProgressBar->SetFgColor( GetFgColor() );
-	}
 }
 
 const char*	CHudItemEffectMeter::GetLabelText( void )


### PR DESCRIPTION
### Related Issue
https://github.com/ValveSoftware/Source-1-Games/issues/2498

### Implementation
- Removed the functionality that changes a full item meter's color to red. The argument for removing this function is that it currently prevents users from setting their own item meter color as it will be overwritten by this function. Another point is that it's only meant to be used by a few weapons like the Cow Mangler and Phlogistinator, whereas others like Milk and Jarate don't change color when full.
- Commented out a declaration for an unused and non-existing item effect file (HudItemEffectMeter_Action.res) as it keeps coming up as an error in console. This is happening in TC2 and current TF2.

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR only contains changes to the engine and/or core game framework
- [x] This PR targets the `community` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | 0.3.1 | <!-- Built, Tested or N/A --> | Windows 10    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
This PR removes the functionality to change color to red outright, which was being suggested to be implemented for all items in https://github.com/mastercomfig/team-comtress-2/issues/199. But because this breaks the ability to set your own item meter color, I feel like this function should be removed.

### Alternatives
Rewritting the function to remember the original foreground color and revert to it when the bar is not full. That would require to pull the set foreground color value from the client scheme and reapply every frame, when the meter is being checked if it is full or not.