### PR TITLE
Separate fading props from pop-in props

### DIFF
--- a/public/gamebspfile.h
+++ b/public/gamebspfile.h
@@ -139,7 +139,11 @@ enum
 
 	STATIC_PROP_NO_PER_TEXEL_LIGHTING = 0x100,				// whether we should do per-texel lightmaps in vrad.
 
-	STATIC_PROP_WC_MASK		= 0x1d8,						// all flags settable in hammer (?)
+	//STATIC_PROP_WC_MASK		= 0x1d8,						// all flags settable in hammer (?)
+															// (fiend) commenting out because it ultimately goes unused and i need the space.
+
+	// (fiend) Added to the end, but automatically computed like the ones up top
+	STATIC_PROP_FLAG_POPS	= 0x1d8,
 };
 
 struct StaticPropDictLump_t

--- a/utils/vbsp/staticprop.cpp
+++ b/utils/vbsp/staticprop.cpp
@@ -51,6 +51,7 @@ struct StaticPropBuild_t
 	float	m_FadeMinDist;
 	float	m_FadeMaxDist;
 	bool	m_FadesOut;
+	bool	m_PopsOut;
 	float	m_flForcedFadeScale;
 	unsigned short	m_nMinDXLevel;
 	unsigned short	m_nMaxDXLevel;
@@ -500,9 +501,13 @@ static void AddStaticPropToLump( StaticPropBuild_t const& build )
 	propLump.m_Solid = build.m_Solid;
 	propLump.m_Skin = build.m_Skin;
 	propLump.m_Flags = build.m_Flags;
-	if (build.m_FadesOut)
+	if ( build.m_FadesOut )
 	{
 		propLump.m_Flags |= STATIC_PROP_FLAG_FADES;
+	}
+	if ( build.m_PopsOut )
+	{
+		propLump.m_Flags |= STATIC_PROP_FLAG_POPS;
 	}
 	propLump.m_FadeMinDist = build.m_FadeMinDist;
 	propLump.m_FadeMaxDist = build.m_FadeMaxDist;
@@ -573,13 +578,13 @@ void EmitStaticProps()
 	if ( physicsFactory )
 	{
 		s_pPhysCollision = (IPhysicsCollision *)physicsFactory( VPHYSICS_COLLISION_INTERFACE_VERSION, NULL );
-		if( !s_pPhysCollision )
+		if ( !s_pPhysCollision )
 			return;
 	}
 
 	// Generate a list of lighting origins, and strip them out
 	int i;
-	for ( i = 0; i < num_entities; ++i)
+	for ( i = 0; i < num_entities; ++i )
 	{
 		char* pEntity = ValueForKey(&entities[i], "classname");
 		if (!Q_strcmp(pEntity, "info_lighting"))
@@ -589,7 +594,7 @@ void EmitStaticProps()
 	}
 
 	// Emit specifically specified static props
-	for ( i = 0; i < num_entities; ++i)
+	for ( i = 0; i < num_entities; ++i )
 	{
 		char* pEntity = ValueForKey(&entities[i], "classname");
 		if (!strcmp(pEntity, "static_prop") || !strcmp(pEntity, "prop_static"))
@@ -602,6 +607,7 @@ void EmitStaticProps()
 			build.m_Solid = IntForKey( &entities[i], "solid" );
 			build.m_Skin = IntForKey( &entities[i], "skin" );
 			build.m_FadeMaxDist = FloatForKey( &entities[i], "fademaxdist" );
+			build.m_FadeMinDist = FloatForKey( &entities[i], "fademindist" );
 			build.m_Flags = 0;//IntForKey( &entities[i], "spawnflags" ) & STATIC_PROP_WC_MASK;
 			if (IntForKey( &entities[i], "ignorenormals" ) == 1)
 			{
@@ -625,9 +631,9 @@ void EmitStaticProps()
 				build.m_Flags |= STATIC_PROP_SCREEN_SPACE_FADE;
 			}
 
-			if (IntForKey( &entities[i], "generatelightmaps") == 0)
+			if (IntForKey( &entities[i], "generatelightmaps" ) == 0)
 			{
-				build.m_Flags |= STATIC_PROP_NO_PER_TEXEL_LIGHTING;			
+				build.m_Flags |= STATIC_PROP_NO_PER_TEXEL_LIGHTING;
 				build.m_LightmapResolutionX = 0;
 				build.m_LightmapResolutionY = 0;
 			}
@@ -646,15 +652,16 @@ void EmitStaticProps()
 			{
 				build.m_flForcedFadeScale = 1;
 			}
-			build.m_FadesOut = (build.m_FadeMaxDist > 0);
+			build.m_FadesOut = (build.m_FadeMaxDist > 0 && build.m_FadeMaxDist != build.m_FadeMinDist && build.m_FadeMinDist >= 0);
+			build.m_PopsOut = (build.m_FadesOut == 0 && build.m_FadeMaxDist > 0 && (build.m_FadeMinDist < 0 || build.m_FadeMinDist == build.m_FadeMaxDist));
 			build.m_pLightingOrigin = ValueForKey( &entities[i], "lightingorigin" );
 			if (build.m_FadesOut)
-			{			  
+			{
 				build.m_FadeMinDist = FloatForKey( &entities[i], "fademindist" );
-				if (build.m_FadeMinDist < 0)
-				{
-					build.m_FadeMinDist = build.m_FadeMaxDist; 
-				}
+			}
+			else if (build.m_PopsOut)
+			{
+				build.m_FadeMinDist = build.m_FadeMaxDist;
 			}
 			else
 			{


### PR DESCRIPTION
### Related Issue
N/A

### Implementation
This is the consolidated code. The fully separated code had higher framerates, but also much higher variability. For the sake of performance stability, I chose to use this one. It also serves as a good middle ground. Benchmarking results at the bottom.

Add another vbsp compiler flag that separates props that fade from those that pop.
From there the fade code is modified to add an else if statement that checks if it has the pop flag, at which point it does less expensive calculations (ignores things it doesn't need like the distance before a prop starts fading).

Screenspace pop-in is a separate thing because i found that it was cheaper than merging it with screenspace fade, likely due to screenspace fade worrying about more variables. interestingly, this caused a performance increase even on maps _without_ screenspace fade enabled.

### Screenshots
N/A

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR only contains changes to the engine and/or core game framework
- [x] This PR targets the `community` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Built & Tested | N/A  | Windows 10 Home x64 Version 20H2 |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
In order to make room for the new flag, I had to comment out an older flag (`STATIC_PROP_WC_MASK`), which only had one reference, which was also commented out, so it ultimately went unused.

### Alternatives

- Completely separating the fading props from the pop-in ones. This caused higher performance but much higher variability.
- Consolidating the screenspace calculations for both. This resulted in lower framerates and higher variability.

### Performance

Averaged over 5 runs of a demo, full data can be found [here](https://github.com/mastercomfig/team-comtress-2/files/6536926/tc2.benchs.txt)
|         |             FPS             |         Variability         |        MS per frame         |            Time             |
|---------|:-----------------------------:|:-----------------------------:|:-----------------------------:|-----------------------------|
Current TC2 | 253.68 | 32.79 ms | 3.94 ms/f | 9.823 seconds |
Separate pop and fade | 261.84 | 34.52 ms | 3.81 ms/f | 9.517 seconds |
Consolidated pop and fade | 257.73 | 30.48 ms | 3.88 ms/f | 9.669 seconds |
Consolidated + screenspace | 256.50 | 31.26 ms | 3.89 ms/f | 9.715 seconds |

### Other notes

The specs of the computer that benchs were done on is:
- Win 10 Home x64 (Version 20H2)
- Intel I7-6700HQ
- Nvidia GTX 960M
- 16GB Ram

The bench i used for this was just me going around in spectator on a map i compiled (so i knew what kind of props were in it), but i'd really appreciate it if others would try benchmarking this PR vs current TC2 on some more active demos!