### PR TITLE
Fix issues with workshop soundscapes/soundscripts/embedded sounds

### DIFF
--- a/game/client/c_soundscape.cpp
+++ b/game/client/c_soundscape.cpp
@@ -266,6 +266,7 @@ void Soundscape_Update( audioparams_t &audio )
 }
 
 #define SOUNDSCAPE_MANIFEST_FILE				"scripts/soundscapes_manifest.txt"
+#define SOUNDSCAPE_EMBED_FILE					"scripts/soundscapes_embed.txt"
 
 void C_SoundscapeSystem::AddSoundScapeFile( const char *filename )
 {
@@ -333,6 +334,11 @@ bool C_SoundscapeSystem::Init()
 		if ( mapSoundscapeFilename && filesystem->FileExists( mapSoundscapeFilename ) )
 		{
 			AddSoundScapeFile( mapSoundscapeFilename );
+		}
+		// only load embedded soundscape file if map soundscape file doesn't exist
+		else if ( SOUNDSCAPE_EMBED_FILE && filesystem->FileExists( SOUNDSCAPE_EMBED_FILE ) )
+		{
+			AddSoundScapeFile( SOUNDSCAPE_EMBED_FILE );
 		}
 	}
 	else

--- a/game/client/c_soundscape.cpp
+++ b/game/client/c_soundscape.cpp
@@ -336,7 +336,7 @@ bool C_SoundscapeSystem::Init()
 			AddSoundScapeFile( mapSoundscapeFilename );
 		}
 		// only load embedded soundscape file if map soundscape file doesn't exist
-		else if ( SOUNDSCAPE_EMBED_FILE && filesystem->FileExists( SOUNDSCAPE_EMBED_FILE ) )
+		else if ( filesystem->FileExists( SOUNDSCAPE_EMBED_FILE, "BSP" ) )
 		{
 			AddSoundScapeFile( SOUNDSCAPE_EMBED_FILE );
 		}

--- a/game/shared/SoundEmitterSystem.cpp
+++ b/game/shared/SoundEmitterSystem.cpp
@@ -305,7 +305,7 @@ public:
 				soundemitterbase->AddSoundOverrides( scriptfile );
 			}
 			// only load embedded level sounds file if map level sounds file doesn't exist
-			else if ( filesystem->FileExists( EMBED_LEVEL_SOUNDS_FILE, "GAME" ) )
+			else if ( filesystem->FileExists( EMBED_LEVEL_SOUNDS_FILE, "BSP" ) )
 			{
 				soundemitterbase->AddSoundOverrides( EMBED_LEVEL_SOUNDS_FILE );
 			}
@@ -319,7 +319,7 @@ public:
 			soundemitterbase->AddSoundOverrides( scriptfile );
 		}
 		// only load embedded level sounds file if map level sounds file doesn't exist
-		else if ( filesystem->FileExists( EMBED_LEVEL_SOUNDS_FILE, "GAME" ) )
+		else if ( filesystem->FileExists( EMBED_LEVEL_SOUNDS_FILE, "BSP" ) )
 		{
 			soundemitterbase->AddSoundOverrides( EMBED_LEVEL_SOUNDS_FILE );
 		}

--- a/game/shared/SoundEmitterSystem.cpp
+++ b/game/shared/SoundEmitterSystem.cpp
@@ -57,6 +57,8 @@ void ClearModelSoundsCache();
 
 #endif // !CLIENT_DLL
 
+#define EMBED_LEVEL_SOUNDS_FILE 				"maps/embed_level_sounds.txt"
+
 void WaveTrace( char const *wavname, char const *funcname )
 {
 	if ( IsX360() && !IsDebug() )
@@ -302,6 +304,11 @@ public:
 			{
 				soundemitterbase->AddSoundOverrides( scriptfile );
 			}
+			// only load embedded level sounds file if map level sounds file doesn't exist
+			else if ( filesystem->FileExists( EMBED_LEVEL_SOUNDS_FILE, "GAME" ) )
+			{
+				soundemitterbase->AddSoundOverrides( EMBED_LEVEL_SOUNDS_FILE );
+			}
 		}
 #else
 		Q_StripExtension( mapname, scriptfile, sizeof( scriptfile ) );
@@ -310,6 +317,11 @@ public:
 		if ( filesystem->FileExists( scriptfile, "GAME" ) )
 		{
 			soundemitterbase->AddSoundOverrides( scriptfile );
+		}
+		// only load embedded level sounds file if map level sounds file doesn't exist
+		else if ( filesystem->FileExists( EMBED_LEVEL_SOUNDS_FILE, "GAME" ) )
+		{
+			soundemitterbase->AddSoundOverrides( EMBED_LEVEL_SOUNDS_FILE );
 		}
 #endif
 

--- a/game_clean/copy/tf/gameinfo.txt
+++ b/game_clean/copy/tf/gameinfo.txt
@@ -91,6 +91,9 @@
 			// The map search pack is mounted at the top of the search path list,
 			// but only while you are connected that server and on that map.
 			game+download	tf/download
+
+			// Workshop folder needs a search path to be able to cache sounds
+			game				|all_source_engine_paths|../../workshop/content/440
 		}
 	}
 


### PR DESCRIPTION
### Related Issue
https://github.com/ValveSoftware/Source-1-Games/issues/2701
#468 

### Implementation
* Loads a soundscape named "scripts/soundscape_embed.txt" from within a workshop BSP, only if soundscape_fullmapname.txt is not present
* Loads a level sounds file named "maps/embed_level_sounds.txt" from within the workshop BSP, only if fullmapname_level_sounds.txt is not present
* Creates a new GAME search path in the TF2 workshop folder
* Note that the embedded file handling matches the implementation used for nav files already

### Screenshots
<!-- Add screenshots if applicable -->

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [ ] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR only contains changes to the engine and/or core game framework
- [x] This PR targets the `community` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [ ] This PR does not introduce any regressions.
- [ ] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
<!-- Any caveats and side effects of this PR -->

### Alternatives
<!-- Alternatives that were considered -->
Considering reworking `filesystem_init.cpp` to add a token for `|workshop_path|` or something so that the GameID `440` doesn't have to be hardcoded into the new search path.
