### PR TITLE
Correctly copy paste the right glow fade code for the Demoman's charge

### DIFF
--- a/game/client/tf/c_tf_player.cpp
+++ b/game/client/tf/c_tf_player.cpp
@@ -2360,7 +2360,7 @@ public:
 				else if ( pPlayer->m_Shared.m_bChargeGlowing )
 				{
 					// Cool down the charge glow after charging.
-					float flGlow = 1.f - MIN( (gpGlobals->curtime - pPlayer->m_Shared.m_flLastNoChargeTime) / 0.3f, 1.f );
+					float flGlow = 1.f - MIN((gpGlobals->curtime - pPlayer->m_Shared.m_flLastNoChargeTime - 1.5f) / 0.3f,1);
 
 					if ( flGlow <= 0 )
 					{


### PR DESCRIPTION
I noticed this when digging through the crit proxy for something else, and I figured I could submit a fix for it.

### Implementation
The Demoman's charge glow is supposed to fade in and out, however it only fades out when cancelled through a melee attack. This can be fixed by simply copypasting the code from the melee attack fade out to the other part of the function

### Screenshots
https://twitter.com/stick_twt/status/1472464099845963777

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [ ] This PR only contains changes to the engine and/or core game framework
- [x] This PR targets the `community` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [ ] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | N/A | N/A | N/A |
|   Linux | N/A | N/A | N/A |
|  Mac OS | N/A | N/A | N/A |

### Caveats
Probably nothing, its barely noticeable as is

### Alternatives
Could probably reformat the maths to make it last slightly longer, but this is probably what Valve intended
