### PR TITLE
Fix Dispenser heals through transparent walls

### DIFF
--- a/game/server/tf/tf_obj_dispenser.cpp
+++ b/game/server/tf/tf_obj_dispenser.cpp
@@ -973,7 +973,7 @@ void CObjectDispenser::StopHealing( CBaseEntity *pOther )
 //-----------------------------------------------------------------------------
 bool CObjectDispenser::CouldHealTarget( CBaseEntity *pTarget )
 {
-	if ( !HasSpawnFlags( SF_DISPENSER_IGNORE_LOS ) && !pTarget->FVisible( this, MASK_BLOCKLOS ) )
+	if ( !HasSpawnFlags( SF_DISPENSER_IGNORE_LOS ) && !pTarget->FVisible( this, MASK_SHOT | CONTENTS_GRATE ) )
 		return false;
 
 	if ( pTarget->IsPlayer() && pTarget->IsAlive() )


### PR DESCRIPTION
### Related Issue
N/A

### Implementation
Fixes an issue with dispensers healing through walls that are marked as "transparent" (glass windows, grates, etc.)
Healing is now done by checking the same criteria as sentry targeting. which checks if the surface can be shot through.

This can be easily tested in game with the chainlink fences on pl_Swiftwater

### Screenshots
N/A

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR only contains changes to the engine and/or core game framework
- [x] This PR targets the `community` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | N/A | Tested | Windows 10 Home |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
If for some reason the sentry gun's targeting criteria is bugged, this is bugged as well.

### Alternatives
N/A
