### PR TITLE
Fix wrong effect color for dissolve deaths

### DIFF
--- a/game/client/tf/c_tf_player.cpp
+++ b/game/client/tf/c_tf_player.cpp
@@ -735,6 +735,8 @@ private:
 	float m_flHeadScale;
 	float m_flTorsoScale;
 	float m_flHandScale;
+	int m_iKillerTeam;	// Grab the team of the killer, so that effects like dissolving are consistent rather than per team.
+						// fixes suicides with dissolving weapons using the wrong team color
 
 	CMaterialReference		m_MaterialOverride;
 
@@ -769,6 +771,7 @@ IMPLEMENT_CLIENTCLASS_DT_NOBASE( C_TFRagdoll, DT_TFRagdoll, CTFRagdoll )
 	RecvPropFloat( RECVINFO( m_flHeadScale ) ),
 	RecvPropFloat( RECVINFO( m_flTorsoScale ) ),
 	RecvPropFloat( RECVINFO( m_flHandScale ) ),
+	RecvPropInt( RECVINFO( m_iKillerTeam ) ),
 END_RECV_TABLE()
 
 //-----------------------------------------------------------------------------
@@ -808,6 +811,7 @@ C_TFRagdoll::C_TFRagdoll()
 	m_flHeadScale = 1.f;
 	m_flTorsoScale = 1.f;
 	m_flHandScale = 1.f;
+	m_iKillerTeam = -1;
 
 	UseClientSideAnimation();
 
@@ -1869,16 +1873,15 @@ void C_TFRagdoll::DissolveEntity( CBaseEntity* pEnt )
 		pDissolve->SetRenderColor( 255, 255, 255, 255 );
 
 		Vector vColor;
-		if ( m_iTeam == TF_TEAM_BLUE )
+		if ( m_iKillerTeam == TF_TEAM_BLUE )
 		{
-			vColor = TF_PARTICLE_WEAPON_RED_1 * 255;
-			pDissolve->SetEffectColor( vColor );
+			vColor = TF_PARTICLE_WEAPON_BLUE_1 * 255;
 		}
 		else
 		{
-			vColor = TF_PARTICLE_WEAPON_BLUE_1 * 255;
-			pDissolve->SetEffectColor( vColor );
+			vColor = TF_PARTICLE_WEAPON_RED_1 * 255;
 		}
+		pDissolve->SetEffectColor( vColor );
 
 		pDissolve->m_vDissolverOrigin = GetAbsOrigin();
 

--- a/game/client/tf/c_tf_player.cpp
+++ b/game/client/tf/c_tf_player.cpp
@@ -735,7 +735,7 @@ private:
 	float m_flHeadScale;
 	float m_flTorsoScale;
 	float m_flHandScale;
-	int m_iKillerTeam;	// Grab the team of the killer, so that effects like dissolving are consistent rather than per team.
+	int m_iKillerTeam;	// (fiend) Grab the team of the killer, so that effects like dissolving are consistent rather than per team.
 						// fixes suicides with dissolving weapons using the wrong team color
 
 	CMaterialReference		m_MaterialOverride;

--- a/game/server/tf/tf_player.cpp
+++ b/game/server/tf/tf_player.cpp
@@ -477,6 +477,7 @@ public:
 	CNetworkVar( float, m_flHeadScale );
 	CNetworkVar( float, m_flTorsoScale );
 	CNetworkVar( float, m_flHandScale );
+	CNetworkVar( int, m_iKillerTeam );
 	CUtlVector<CHandle<CEconWearable > > m_hRagWearables;
 };
 
@@ -506,6 +507,7 @@ IMPLEMENT_SERVERCLASS_ST_NOBASE( CTFRagdoll, DT_TFRagdoll )
 	SendPropFloat( SENDINFO( m_flHeadScale ) ),
 	SendPropFloat( SENDINFO( m_flTorsoScale ) ),
 	SendPropFloat( SENDINFO( m_flHandScale ) ),
+	SendPropInt( SENDINFO( m_iKillerTeam ), 3, SPROP_UNSIGNED ),
 END_SEND_TABLE()
 
 // -------------------------------------------------------------------------------- //
@@ -12259,7 +12261,7 @@ void CTFPlayer::Event_Killed( const CTakeDamageInfo &info )
 	// Create the ragdoll entity.
 	if ( bGib || bRagdoll )
 	{
-		CreateRagdollEntity( bGib, bBurning, bElectrocuted, bOnGround, bCloakedCorpse, iGoldRagdoll != 0, iIceRagdoll != 0, iRagdollsBecomeAsh != 0, iCustomDamage, ( iCritOnHardHit != 0 ) );
+		CreateRagdollEntity( bGib, bBurning, bElectrocuted, bOnGround, bCloakedCorpse, iGoldRagdoll != 0, iIceRagdoll != 0, iRagdollsBecomeAsh != 0, iCustomDamage, ( iCritOnHardHit != 0 ), info.GetInflictor()->GetTeamNumber() );
 	}
 
 #ifdef STAGING_ONLY
@@ -14874,7 +14876,7 @@ void CTFPlayer::CreateRagdollEntity( void )
 //-----------------------------------------------------------------------------
 // Purpose: Create a ragdoll entity to pass to the client.
 //-----------------------------------------------------------------------------
-void CTFPlayer::CreateRagdollEntity( bool bGib, bool bBurning, bool bElectrocuted, bool bOnGround, bool bCloakedCorpse, bool bGoldRagdoll, bool bIceRagdoll, bool bBecomeAsh, int iDamageCustom, bool bCritOnHardHit )
+void CTFPlayer::CreateRagdollEntity( bool bGib, bool bBurning, bool bElectrocuted, bool bOnGround, bool bCloakedCorpse, bool bGoldRagdoll, bool bIceRagdoll, bool bBecomeAsh, int iDamageCustom, bool bCritOnHardHit, int iKillerTeam )
 {
 	// If we already have a ragdoll destroy it.
 	CTFRagdoll *pRagdoll = dynamic_cast<CTFRagdoll*>( m_hRagdoll.Get() );
@@ -14910,6 +14912,7 @@ void CTFPlayer::CreateRagdollEntity( bool bGib, bool bBurning, bool bElectrocute
 		pRagdoll->m_flHeadScale = m_flHeadScale;
 		pRagdoll->m_flTorsoScale = m_flTorsoScale;
 		pRagdoll->m_flHandScale = m_flHandScale;
+		pRagdoll->m_iKillerTeam = iKillerTeam;
 	}
 
 	// Turn off the player.

--- a/game/server/tf/tf_player.h
+++ b/game/server/tf/tf_player.h
@@ -381,7 +381,7 @@ public:
 
 	// Death & Ragdolls.
 	virtual void CreateRagdollEntity( void );
-	void CreateRagdollEntity( bool bGib, bool bBurning, bool bElectrocuted, bool bOnGround, bool bCloakedCorpse, bool bGoldRagdoll, bool bIceRagdoll, bool bBecomeAsh, int iDamageCustom = 0, bool bCritOnHardHit = false );
+	void CreateRagdollEntity( bool bGib, bool bBurning, bool bElectrocuted, bool bOnGround, bool bCloakedCorpse, bool bGoldRagdoll, bool bIceRagdoll, bool bBecomeAsh, int iDamageCustom = 0, bool bCritOnHardHit = false, int iKillerTeam = -1 );
 	void DestroyRagdoll( void );
 	CNetworkHandle( CBaseEntity, m_hRagdoll );	// networked entity handle 
 	virtual bool ShouldGib( const CTakeDamageInfo &info ) OVERRIDE;


### PR DESCRIPTION
This fixes an issue where suiciding with a weapon that dissolves your ragdoll (Cow Mangler, Short Circuit, etc.), would use the particle effects of the wrong team.
This PR makes it consistent so that the particle effect color is the same as the projectile color.
NOTE: I at first wasn't sure whether to even call this a bug or oversight, but I decided that it was an oversight because:
A. the particle effects used are intended to be of the _opposite_ team, because you got killed by a projectile of that color
B. the only potential intended purpose I could think of for this was recognizing what team someone was on, but it'd be weird to have players try to associate their team with the opposite team's color?

### Implementation
1. Add new integer input to CTFRagdoll `m_iKillerTeam`, which grabs the team ID of the killer
2. Change dissolve color code to check the team of the killer instead of the player's team and change the color accordingly
(also simplify code by moving `pDissolve->SetEffectColor( vColor );` outside of the if-else.

### Screenshots
LIVE TF2: Blue player kills self with Cow Mangler, dissolves into red particles
https://user-images.githubusercontent.com/46549454/161502007-f3d2f996-e77b-4318-bf36-237b3c69d051.mp4
PR: Blue player kills enemy with Cow Mangler, who dissolves into blue, before killing self, also dissolving into blue.
https://user-images.githubusercontent.com/46549454/161502157-bcb0e393-d1f5-43e2-8a2b-4e0fa2c66785.mp4

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR only contains changes to the engine and/or core game framework
- [x] This PR targets the `community` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | Tested | Tested (new code requires networked variables) | Windows 10 21H1 |
|   Linux | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
N/A

### Alternatives
I'm not a big fan of how I implemented this, and preferably would like to find an alternative which doesn't require changing of CTFRagdoll.
If anyone has ideas for checking who inflicted the last hit or if the death was self-inflicted inside the dissolve code rather than the ragdoll code, it'd be very appreciated!

### Notes
With the current implementation of grabbing the killer's team, this could potentially be used for other team-based or colored ragdoll effects?
the fact that its team based means that there could potentially be a different effect for "neutral" teams such as the halloween bosses.

Decaps and backstabs have a switch case in `tf_player_shared` function `GetSequenceForDeath`, where if the damage of the final blow is a certain type, it plays a specific animation.
notably, dissolving is missing from here and is its own separate thing rather than just an animation with some effects, ideally the dissolve code would be here instead?