### PR TITLE
add docker-compose support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -389,3 +389,6 @@ generated_proto*/
 !src/lib/public/x64/tier3.lib
 !src/lib/public/x64/vpklib.lib
 !src/lib/public/x64/vstdlib.lib
+
+# ignore container ccache
+ccache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+
+services:
+  build:
+    environment:
+      - CCACHE_DIR=/ccache
+    image: registry.gitlab.steamos.cloud/steamrt/sniper/sdk
+    container_name: tf2-patches-build
+    volumes:
+      - ./:/build:z
+      - ./ccache:/ccache:z
+    entrypoint: /build/src/build.sh


### PR DESCRIPTION
this is dependent on #629 

### Related Issue
n/a

### Implementation
this allows for easy (re)builds on any system supporting docker/podman with two commands:

```
podman-compose up # initial build
podman start -a tf2-patches-build # subsequent builds
```

### Screenshots
n/a

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR only contains changes to the engine and/or core game framework
- [ ] This PR targets the `community` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [ ] This change has been filed as an issue.
- [x] No other PRs address this.
- [x] This PR is as minimal as possible.
- [x] This PR does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | n/a| n/a | n/a   |
|   Linux | Built/Tested | Built | `6.1.11-200.fc37.x86_64` |
|  Mac OS | n/a| n/a | n/a      |

### Caveats
the debug symbols are changed to the root of the container (`/build`), not the root of the current working directory. this can be a little confusing but i don't find it to be that big of an issue considering the rest of the file structure is still conveyed.

### Alternatives
downloading the sdk and running `schroot` could be a good alternative to some and of course it still is, but this makes development much more streamlined and hassle-free. it also follows valve's current [guidelines](https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/main/docs/slr-for-game-developers.md#build-environment) on how to build native linux games.
