### PR TITLE
only allow atomizer triple-jump when fully deployed

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -12164,17 +12164,15 @@ bool CTFPlayer::CanAirDash( void ) const
 	}
 
 	int iDashCount = tf_scout_air_dash_count.GetInt();
-	if ( GetActiveWeapon() && GetActiveTFWeapon()->GetWeaponID() == TF_WEAPON_BAT )
+	CTFWeaponBase* pWeapon = GetActiveTFWeapon();
+	if ( pWeapon && pWeapon->GetWeaponID() == TF_WEAPON_BAT )
 	{
-		if ( gpGlobals->curtime - pLastWeapon->m_flLastDeployTime > 0.7f )
+		if ( gpGlobals->curtime - pWeapon->GetLastDeployTime() > 0.7f )
 		{
 			CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( GetActiveWeapon(), iDashCount, air_dash_count );
 		}
 	}
-	else
-	{
-		CALL_ATTRIB_HOOK_INT( iDashCount, air_dash_count );
-	}
+
 	if ( m_Shared.GetAirDash() >= iDashCount ) 
 		return false;
 


### PR DESCRIPTION

### Related Issue
<!-- Number of the issue where this topic was mentioned -->

### Implementation
the previous changes also didn't compile, due to pLastWeapon not being defined. And when that was fixed, it allowed me to triple-jump when holding other weapons.

### Screenshots
<!-- Add screenshots if applicable -->

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR only contains changes to the engine and/or core game framework
- [x] This PR targets the `community` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [ ] This change has been filed as an issue.
- [ ] No other PRs address this.
- [x] This PR is as minimal as possible.
- [ ] This PR does not introduce any regressions.
- [ ] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.

### Testing Checklist
<!-- You do not have to test on all platforms to open a pull request -->
|         |            Client             |            Server             | Version                     |
|---------|:-----------------------------:|:-----------------------------:|-----------------------------|
| Windows | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Windows 10 -->    |
|   Linux | Built, Tested | <!-- Built, Tested or N/A --> | <!-- `uname -vr` output --> |
|  Mac OS | <!-- Built, Tested or N/A --> | <!-- Built, Tested or N/A --> | <!-- e.g. Catalina -->      |

### Caveats
<!-- Any caveats and side effects of this PR -->

### Alternatives
<!-- Alternatives that were considered -->
