### PR TITLE
fix: Remove reduntant output and intermediate directories for server and client bases

### DIFF
--- a/src/game/client/client_base.vpc
+++ b/src/game/client/client_base.vpc
@@ -45,12 +45,6 @@ $Configuration	"Release"
 
 $Configuration
 {
-	$General
-	{
-		$OutputDirectory			".\$GAMENAME"
-		$IntermediateDirectory		".\$GAMENAME"
-	}
-
 	$Compiler
 	{
 		$AdditionalIncludeDirectories	".\;$BASE;$SRCDIR\vgui2\include;$SRCDIR\vgui2\controls;$SRCDIR\game\shared;.\game_controls;$SRCDIR\thirdparty\sixensesdk\include"

--- a/src/game/server/server_base.vpc
+++ b/src/game/server/server_base.vpc
@@ -45,12 +45,6 @@ $Configuration	"Release"
 
 $Configuration
 {
-	$General
-	{
-		$OutputDirectory			".\$GAMENAME"
-		$IntermediateDirectory		".\$GAMENAME"
-	}
-
 	$Compiler
 	{
 		$AdditionalIncludeDirectories	"$BASE;.\;$SRCDIR\game\shared;$SRCDIR\utils\common;$SRCDIR\game\shared\econ;$SRCDIR\game\server\NextBot"


### PR DESCRIPTION
`server_base.vpc` and `client_base.vpc` had duplicate `OutputDirectory` and `IntermediateDirectory` which overwrote the debug and release blocks above, causing output files to be shoved into the game directory. I've compiled it and it seems to work as expected now.

### Checklist
<!-- You MUST answer "yes" to all of these to open a pull request -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [x] No other PRs implement this idea.
- [x] This PR does not introduce any regressions.
- [x] I certify that this PR is my own entirely original work, or I have permission from and have attributed the relevant authors.
- [x] I have agreed to and signed this project's [Contributor License Agreement](https://cla-assistant.io/mastercomfig/team-comtress-2).
- [x] This PR only contains changes to the engine and/or core game framework
- [x] This PR targets the `changes` or `base` branch.

<!-- You do NOT have to answer "yes" to the following, but please mark them if relevant -->
<!-- To tick a checkbox, place an 'x' in it, like so: [x] -->
- [ ] This bug has been filed as an issue.
- [x] No other PRs fix this bug.
- [x] This fix is as minimal as possible.
- [x] This fix does not introduce any regressions.
- [x] This PR has been built and locally tested on at least one platform.
- [ ] This PR has been tested on all platforms, on both a dedicated server and on a listen server.